### PR TITLE
Sett basename til react-router

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ const base =
 
 export default defineConfig({
   base,
-  plugins: [reactRouter(), tsconfigPaths()],
+  plugins: [reactRouter({ basename: "/rapportering" }), tsconfigPaths()],
   build: {
     cssMinify: true,
     ssr: true,


### PR DESCRIPTION
Jeg klarer ikke å se at det er noe automatikk som spleier path fra vite inn til react-router, så ganske sikker på at den må settes manuelt her også.