### PR TITLE
omskriv fra dom-struktur til mer brukerfokusert

### DIFF
--- a/app/components/rapporteringsperiode-liste/Innsendt.tsx
+++ b/app/components/rapporteringsperiode-liste/Innsendt.tsx
@@ -33,7 +33,9 @@ export function Innsendt({ mottattDato, tilOgMed, sisteFristForTrekk, status }: 
           sisteFristForTrekk ? formatterDato({ dato: sisteFristForTrekk }) : "Ingen frist"
         }`}
       >
-        <Tag variant="error">{formatterDato({ dato: mottattDato })}</Tag>
+        <Tag role="alert" variant="error">
+          {formatterDato({ dato: mottattDato })}
+        </Tag>
       </Tooltip>
     );
   }

--- a/vitest/components/rapporteringsperiode-liste/Innsendt.spec.tsx
+++ b/vitest/components/rapporteringsperiode-liste/Innsendt.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { addDays } from "date-fns";
 import { describe, expect, test } from "vitest";
 
@@ -6,13 +6,15 @@ import { Innsendt } from "~/components/rapporteringsperiode-liste/Innsendt";
 import { SISTE_FRIST } from "~/components/rapporteringsperiode-liste/Innsendt";
 import { formatereDato } from "~/mocks/mock-rapporteringsperioder.utils";
 import { RAPPORTERINGSPERIODE_STATUS } from "~/utils/constants";
+import { formatterDato } from "~/utils/dato.utils";
 
 describe("Innsendt", () => {
   test("skal vise error tag hvis SISTE_FRIST er passert", () => {
     const tilOgMed = "2025-02-09";
     const mottattDato = formatereDato(addDays(new Date(tilOgMed), SISTE_FRIST + 1));
+    const mottatDatoFormattert = formatterDato({ dato: mottattDato });
 
-    const { container } = render(
+    render(
       <Innsendt
         mottattDato={mottattDato}
         tilOgMed={tilOgMed}
@@ -21,14 +23,15 @@ describe("Innsendt", () => {
       />
     );
 
-    expect(container.querySelector(".navds-tag--error")).toBeInTheDocument();
+    expect(screen.getByText(mottatDatoFormattert)).toBeInTheDocument();
   });
 
   test("skal ikke vise error tag hvis SISTE_FRIST ikke er passert", () => {
     const tilOgMed = "2025-02-09";
     const mottattDato = formatereDato(addDays(new Date(tilOgMed), 1));
+    const mottatDatoFormattert = formatterDato({ dato: mottattDato });
 
-    const { container } = render(
+    render(
       <Innsendt
         mottattDato={mottattDato}
         tilOgMed={tilOgMed}
@@ -36,6 +39,7 @@ describe("Innsendt", () => {
         status={RAPPORTERINGSPERIODE_STATUS.Ferdig}
       />
     );
-    expect(container.querySelector(".navds-tag--neutral")).toBeInTheDocument();
+
+    expect(screen.getByText(mottatDatoFormattert)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Jeg har omskrevet testene fra container.querySelector til screen.getByText for å gjøre dem mer robuste og brukerfokuserte.

- Testene speiler nå faktisk brukeropplevelse.
- 
- De er mindre avhengige av CSS-klasser og DOM-struktur.
- 
- De følger beste praksis for tilgjengelighet og semantikk.
- 
- Mindre risiko for at testene feiler ved refaktorering (fra Aksel).