### PR TITLE
Oppdater utvidet informasjon

### DIFF
--- a/app/components/rapporteringsperiode-detaljer/PeriodeDetaljer.tsx
+++ b/app/components/rapporteringsperiode-detaljer/PeriodeDetaljer.tsx
@@ -14,90 +14,12 @@ interface IProps {
 export function PeriodeDetaljer({ periode, personId }: IProps) {
   const erArbeidssoker = periode.registrertArbeidssoker;
   const erKorrigert = !!periode.korrigering?.korrigererMeldekortId;
-  const erUtfyltAvSaksbehandler = periode.kilde?.rolle === "Saksbehandler" && !erKorrigert;
   const kanFyllesUt = periode.kanSendes && periode.status === RAPPORTERINGSPERIODE_STATUS.Opprettet;
 
   return (
     <div className={styles.periodeDetaljer}>
-      <dl className={styles.detailList}>
-        {periode.registrertArbeidssoker && (
-          <>
-            <dt>Svar på spørsmål om arbeidssøkerregistrering:</dt>
-            <dd>
-              <Tag variant={erArbeidssoker ? "success" : "error"} size="small">
-                {erArbeidssoker ? "Ja" : "Nei"}
-              </Tag>
-            </dd>
-          </>
-        )}
-        {erKorrigert && (
-          <>
-            <dt>Korrigering av meldekort:</dt>
-            <dd>
-              {periode.registrertArbeidssoker && (
-                <Tag variant="success" size="small">
-                  Ja
-                </Tag>
-              )}
-            </dd>
-            <dt>Korrigert av:</dt>
-            <dd>
-              {periode?.kilde?.rolle === "Saksbehandler"
-                ? `Saksbehandler (${periode?.kilde?.ident})`
-                : periode?.kilde?.rolle}
-            </dd>
-            {periode.innsendtTidspunkt && (
-              <>
-                <dt>Dato for korrigering:</dt>
-                <dd>
-                  {formatterDato({
-                    dato: periode.innsendtTidspunkt,
-                    format: DatoFormat.DagMndAarLang,
-                  })}
-                </dd>
-              </>
-            )}
-          </>
-        )}
-
-        {erUtfyltAvSaksbehandler && (
-          <>
-            <dt>Utfylt av:</dt>
-            <dd>
-              {periode?.kilde?.rolle === "Saksbehandler"
-                ? `Saksbehandler (${periode?.kilde?.ident})`
-                : periode?.kilde?.rolle}
-            </dd>
-            {periode.innsendtTidspunkt && (
-              <>
-                <dt>Meldekort innsendt:</dt>
-                <dd>
-                  {formatterDato({
-                    dato: periode.innsendtTidspunkt,
-                    format: DatoFormat.DagMndAarLang,
-                  })}
-                </dd>
-              </>
-            )}
-            {periode.begrunnelse && (
-              <>
-                <dt>Begrunnelse:</dt>
-                <dd>{periode.begrunnelse}</dd>
-              </>
-            )}
-          </>
-        )}
-
-        {periode.korrigering?.begrunnelse && (
-          <>
-            <dt>Grunn til korrigering:</dt>
-            <dd>{periode.korrigering.begrunnelse}</dd>
-          </>
-        )}
-      </dl>
-
-      <div>
-        {kanFyllesUt ? (
+      {kanFyllesUt ? (
+        <div>
           <Button
             as="a"
             href={`/person/${personId}/periode/${periode.id}/fyll-ut`}
@@ -107,17 +29,56 @@ export function PeriodeDetaljer({ periode, personId }: IProps) {
           >
             Fyll ut meldekort
           </Button>
-        ) : (
-          <Button
-            as="a"
-            href={`/person/${personId}/periode/${periode.id}/korriger`}
-            className={styles.korrigerKnapp}
-            size="small"
-          >
-            Korriger meldekort
-          </Button>
-        )}
-      </div>
+        </div>
+      ) : (
+        <>
+          <dl className={styles.detailList}>
+            {periode.innsendtTidspunkt && (
+              <>
+                <dt>Dato for innsending:</dt>
+                <dd>
+                  {formatterDato({
+                    dato: periode.innsendtTidspunkt,
+                    format: DatoFormat.DagMndAarLang,
+                  })}
+                </dd>
+              </>
+            )}
+            <dt>{erKorrigert ? "Korrigert" : "Innsendt"} av:</dt>
+            <dd>
+              {periode?.kilde?.rolle === "Saksbehandler"
+                ? periode?.kilde?.ident
+                : periode?.kilde?.rolle}
+            </dd>
+            {periode.begrunnelse && (
+              <>
+                <dt>Begrunnelse:</dt>
+                <dd>{periode.begrunnelse}</dd>
+              </>
+            )}
+            {periode.registrertArbeidssoker && (
+              <>
+                <dt>Svar på spørsmål om arbeidssøkerregistrering:</dt>
+                <dd>
+                  <Tag variant={erArbeidssoker ? "success" : "error"} size="small">
+                    {erArbeidssoker ? "Ja" : "Nei"}
+                  </Tag>
+                </dd>
+              </>
+            )}
+          </dl>
+          <div>
+            <Button
+              as="a"
+              href={`/person/${personId}/periode/${periode.id}/korriger`}
+              className={styles.korrigerKnapp}
+              size="small"
+            >
+              Korriger meldekort
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/mocks/data/mock-rapporteringsperioder.ts
+++ b/app/mocks/data/mock-rapporteringsperioder.ts
@@ -164,9 +164,9 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
         id: "period-korrigert-bruker-2-correction",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
+        begrunnelse: "Feil antall arbeidstimer. Hadde jobbet full tid",
         korrigering: {
           korrigererMeldekortId: "period-korrigert-bruker-2-original",
-          begrunnelse: "Feil antall arbeidstimer. Hadde jobbet full tid",
         },
         kilde: {
           rolle: "Bruker" as const,
@@ -203,9 +203,9 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
         id: "period-korrigert-saksbehandler-2-correction",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
+        begrunnelse: "Feil antall arbeidstimer",
         korrigering: {
           korrigererMeldekortId: "period-korrigert-saksbehandler-2-original",
-          begrunnelse: "Feil antall arbeidstimer",
         },
         kilde: {
           rolle: "Saksbehandler" as const,
@@ -479,9 +479,9 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
       periode: {
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
+        begrunnelse: "Glemt å føre aktiviteter.",
         korrigering: {
           korrigererMeldekortId: "period-korrigert-bruker-2-original",
-          begrunnelse: "Glemt å føre aktiviteter.",
         },
         innsendtTidspunkt: null, // Vil bli satt automatisk basert på perioden
         kilde: { rolle: "Bruker" as const, ident: "1234567891011" },
@@ -654,9 +654,9 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
       periode: {
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
+        begrunnelse: "Glemt å føre aktiviteter.",
         korrigering: {
           korrigererMeldekortId: "period-korrigert-bruker-2-original",
-          begrunnelse: "Glemt å føre aktiviteter.",
         },
         innsendtTidspunkt: null, // Vil bli satt automatisk basert på perioden
         kilde: { rolle: "Saksbehandler" as const, ident: "Z993298" },

--- a/app/routes/person.$personId.periode.$periodeId.korriger.tsx
+++ b/app/routes/person.$personId.periode.$periodeId.korriger.tsx
@@ -56,12 +56,12 @@ export default function Periode() {
             </Tag>
           </div>
           <Forhandsvisning periode={periode} />
-          {periode.korrigering?.begrunnelse && (
+          {periode.begrunnelse && (
             <div className={styles.begrunnelseVisning}>
               <Heading level="4" size="small">
                 Begrunnelse for korrigering
               </Heading>
-              <p>{periode.korrigering?.begrunnelse}</p>
+              <p>{periode.begrunnelse}</p>
             </div>
           )}
         </div>
@@ -77,8 +77,8 @@ export default function Periode() {
             <Heading level="4" size="xsmall">
               Saksbehandlers begrunnelse for korrigering
             </Heading>
-            <p className={!korrigertPeriode.korrigering?.begrunnelse ? styles.obligatorisk : ""}>
-              {korrigertPeriode.korrigering?.begrunnelse || "Obligatorisk"}
+            <p className={!korrigertPeriode.begrunnelse ? styles.obligatorisk : ""}>
+              {korrigertPeriode.begrunnelse || "Obligatorisk"}
             </p>
           </div>
         </div>

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -54,7 +54,6 @@ export interface IRapporteringsperiodeDag {
 }
 
 export interface IRapporteringsperiode {
-  begrunnelse: string; // TODO: må avklare om dette er riktig approach
   id: string;
   personId: string;
   ident: string;
@@ -67,9 +66,9 @@ export interface IRapporteringsperiode {
   kanSendesFra: string;
   sisteFristForTrekk: string;
   opprettetAv: string;
+  begrunnelse?: string;
   korrigering: {
     korrigererMeldekortId: string;
-    begrunnelse: string;
   } | null;
   kilde: {
     rolle: "Bruker" | "Saksbehandler";


### PR DESCRIPTION
Etter forespørsel fra design:
oppdater og rydd opp i rekkefølgen til utvidet informasjon, dette rydder også opp i `korrigering.begrunnelse` hvor begrunnelse nå ligger direkte på meldekort/rapp.periode

FØR:
<img width="556" height="628" alt="Screenshot 2025-08-20 at 12 57 33" src="https://github.com/user-attachments/assets/087941e8-676c-4b33-aaf4-a4e81659be84" />


ETTER:
<img width="556" height="628" alt="Screenshot 2025-08-20 at 12 58 12" src="https://github.com/user-attachments/assets/19152445-e5b8-4309-b514-8d769654962e" />