### PR TITLE
Ignorer kall mot sanity i mock

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
+#!/usr/bin/env sh
 pnpm run pre-commit
 pnpm test

--- a/app/mocks/server.ts
+++ b/app/mocks/server.ts
@@ -19,6 +19,13 @@ export const server = setupServer(...handlers);
 export function startMockServer(server: SetupServer) {
   server.listen({
     onUnhandledRequest(request, print) {
+      const url = new URL(request.url);
+
+      // Ignorer Sanity API requests
+      if (url.hostname.includes("sanity.io")) {
+        return;
+      }
+
       logger.warn(`Unhandled request: ${request.url}`);
       print.warning();
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
     "@playwright/test": "^1.60.0",
     "@portabletext/types": "^4.0.2",
     "@react-router/dev": "^7.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@9.39.4(jiti@2.7.0))
+        specifier: ^9.39.4
+        version: 9.39.4
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -138,6 +138,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
@@ -583,15 +586,6 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -3959,10 +3953,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@10.0.1(eslint@9.39.4(jiti@2.7.0))':
-    optionalDependencies:
-      eslint: 9.39.4(jiti@2.7.0)
 
   '@eslint/js@9.39.4': {}
 


### PR DESCRIPTION
For å unngå støy i terminalen så ignorerer vi kall mot sanity i mock.
Nedgraderer også eslint pga peer deps. 