### PR TITLE
juster personlinje for mobil og legg til opprett meldekort knapp

### DIFF
--- a/app/components/personlinje/Personlinje.tsx
+++ b/app/components/personlinje/Personlinje.tsx
@@ -1,10 +1,16 @@
-import { FigureOutwardFillIcon, SilhouetteFillIcon } from "@navikt/aksel-icons";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  FigureOutwardFillIcon,
+  SilhouetteFillIcon,
+} from "@navikt/aksel-icons";
 import { BodyShort, Button, CopyButton } from "@navikt/ds-react";
 import classNames from "classnames";
 import { useMemo, useState } from "react";
 
 import type { IMeldekortPersonlinje } from "~/sanity/fellesKomponenter/personlinje/types";
 import { deepMerge } from "~/utils/deep-merge.utils";
+import { showOpprettMeldekortManuelt } from "~/utils/env.utils";
 import { byggFulltNavn } from "~/utils/person.utils";
 import type { IArbeidssokerperiode, IPerson, IRapporteringsperiode } from "~/utils/types";
 
@@ -24,6 +30,7 @@ const DEFAULT_PERSONLINJE: IMeldekortPersonlinje = {
   genderLabel: "Kjønn:",
   citizenshipLabel: "Statsborgerskap:",
   historyButton: "Historikk",
+  createReportCardButton: "Opprett meldekort",
 };
 
 interface IProps {
@@ -41,6 +48,7 @@ export default function Personlinje({
 }: IProps) {
   const fulltNavn = byggFulltNavn(person.fornavn, person.mellomnavn, person.etternavn);
   const [modalOpen, setModalOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   // Sjekk om data er maskert (kommer fra server-side maskering)
   const erMaskert = fulltNavn.includes("•") || person.ident.includes("•");
@@ -58,13 +66,20 @@ export default function Personlinje({
   return (
     <section className={styles.personlinjeContainer} aria-label={texts.sectionAriaLabel}>
       <div className={styles.personlinje}>
-        <div className={styles.navnContainer}>
+        <button
+          className={styles.navnContainer}
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          aria-controls="personlinje-detaljer"
+          type="button"
+        >
           {person.kjonn && (
             <span
               className={classNames(
                 styles.iconContainer,
                 person.kjonn ? styles[getKjonnKlasse(person.kjonn)] : undefined,
               )}
+              aria-hidden="true"
             >
               {erMann(person.kjonn) && (
                 <SilhouetteFillIcon title="" fontSize="1.5rem" color="white" />
@@ -74,42 +89,79 @@ export default function Personlinje({
               )}
             </span>
           )}
-          <BodyShort size="small">
+          <BodyShort size="small" as="span">
             <strong className={erMaskert ? styles.sensitiv : undefined}>{fulltNavn}</strong>
           </BodyShort>
+          <span className={styles.chevronIcon} aria-hidden="true">
+            {isOpen ? (
+              <ChevronUpIcon title="" fontSize="1.5rem" />
+            ) : (
+              <ChevronDownIcon title="" fontSize="1.5rem" />
+            )}
+          </span>
+        </button>
+
+        <div
+          id="personlinje-detaljer"
+          className={classNames(styles.detaljer, { [styles.detaljerOpen]: isOpen })}
+        >
+          <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
+            {texts.birthNumberLabel}{" "}
+            <strong className={erMaskert ? styles.sensitiv : undefined}>{person.ident}</strong>{" "}
+            {!erMaskert && <CopyButton copyText={person.ident} size="xsmall" />}
+          </BodyShort>
+
+          {person.fodselsdato && (
+            <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
+              {texts.ageLabel} <b>{beregnAlder(person.fodselsdato)}</b>
+            </BodyShort>
+          )}
+
+          {person.kjonn && (
+            <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
+              {texts.genderLabel} <b>{person.kjonn}</b>
+            </BodyShort>
+          )}
+
+          <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
+            {texts.citizenshipLabel} <strong>{person.statsborgerskap}</strong>
+          </BodyShort>
+
+          <div className={styles.knappContainerMobil}>
+            <div>
+              <Button
+                data-color="neutral"
+                variant="secondary"
+                size="xsmall"
+                onClick={() => setModalOpen(true)}
+              >
+                {texts.historyButton}
+              </Button>
+            </div>
+            {showOpprettMeldekortManuelt && (
+              <div>
+                <Button data-color="neutral" variant="secondary" size="xsmall">
+                  {texts.createReportCardButton}
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
-
-        <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
-          {texts.birthNumberLabel}{" "}
-          <strong className={erMaskert ? styles.sensitiv : undefined}>{person.ident}</strong>{" "}
-          {!erMaskert && <CopyButton copyText={person.ident} size="xsmall" />}
-        </BodyShort>
-
-        {person.fodselsdato && (
-          <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
-            {texts.ageLabel} <b>{beregnAlder(person.fodselsdato)}</b>
-          </BodyShort>
-        )}
-
-        {person.kjonn && (
-          <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
-            {texts.genderLabel} <b>{person.kjonn}</b>
-          </BodyShort>
-        )}
-
-        <BodyShort size="small" textColor="subtle" className={styles.infoElement}>
-          {texts.citizenshipLabel} <strong>{person.statsborgerskap}</strong>
-        </BodyShort>
       </div>
-      <div className={styles.historikkKnapp}>
+      <div className={styles.knappContainerDesktop}>
         <Button
           data-color="neutral"
           variant="secondary"
-          size="xsmall"
+          size="small"
           onClick={() => setModalOpen(true)}
         >
           {texts.historyButton}
         </Button>
+        {showOpprettMeldekortManuelt && (
+          <Button data-color="neutral" variant="secondary" size="small">
+            {texts.createReportCardButton}
+          </Button>
+        )}
       </div>
       <HistorikkModal open={modalOpen} onClose={() => setModalOpen(false)} hendelser={events} />
     </section>

--- a/app/components/personlinje/Personlinje.tsx
+++ b/app/components/personlinje/Personlinje.tsx
@@ -66,8 +66,9 @@ export default function Personlinje({
   return (
     <section className={styles.personlinjeContainer} aria-label={texts.sectionAriaLabel}>
       <div className={styles.personlinje}>
+        {/* Mobil - interactive button */}
         <button
-          className={styles.navnContainer}
+          className={styles.navnContainerMobil}
           onClick={() => setIsOpen(!isOpen)}
           aria-expanded={isOpen}
           aria-controls="personlinje-detaljer"
@@ -100,6 +101,29 @@ export default function Personlinje({
             )}
           </span>
         </button>
+
+        {/* Desktop - static div */}
+        <div className={styles.navnContainerDesktop}>
+          {person.kjonn && (
+            <span
+              className={classNames(
+                styles.iconContainer,
+                person.kjonn ? styles[getKjonnKlasse(person.kjonn)] : undefined,
+              )}
+              aria-hidden="true"
+            >
+              {erMann(person.kjonn) && (
+                <SilhouetteFillIcon title="" fontSize="1.5rem" color="white" />
+              )}
+              {erKvinne(person.kjonn) && (
+                <FigureOutwardFillIcon title="" fontSize="1.5rem" color="white" />
+              )}
+            </span>
+          )}
+          <BodyShort size="small" as="span">
+            <strong className={erMaskert ? styles.sensitiv : undefined}>{fulltNavn}</strong>
+          </BodyShort>
+        </div>
 
         <div
           id="personlinje-detaljer"

--- a/app/components/personlinje/personlinje.module.css
+++ b/app/components/personlinje/personlinje.module.css
@@ -1,12 +1,18 @@
 .personlinjeContainer {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding: var(--ax-space-12) var(--ax-space-24);
   background-color: var(--ax-bg-default);
   box-shadow: var(--ax-shadow-dialog);
   position: sticky;
   top: 4rem;
   z-index: 1000;
+}
+
+@media (min-width: 1100px) {
+  .personlinjeContainer {
+    align-items: center;
+  }
 }
 
 .sensitiv {
@@ -22,11 +28,113 @@
 .personlinje {
   display: flex;
   gap: var(--ax-space-24);
-  align-items: center;
+  align-items: flex-start;
+  flex: 1;
+  flex-direction: column;
 }
 
-.historikkKnapp {
+@media (min-width: 1100px) {
+  .personlinje {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.navnContainer {
+  display: flex;
+  align-items: center;
+  gap: var(--ax-space-8);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+  font-family: inherit;
+}
+
+.navnContainer:focus-visible {
+  outline: 2px solid var(--ax-focus-color, #0067c5);
+  outline-offset: 2px;
+  border-radius: var(--ax-radius-small);
+}
+
+@media (min-width: 1100px) {
+  .navnContainer {
+    width: auto;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .navnContainer:focus-visible {
+    outline: none;
+  }
+}
+
+.chevronIcon {
+  display: flex;
+  align-items: center;
   margin-left: auto;
+}
+
+@media (min-width: 1100px) {
+  .chevronIcon {
+    display: none;
+  }
+}
+
+.detaljer {
+  display: none;
+  flex-direction: column;
+  gap: var(--ax-space-12);
+}
+
+.detaljerOpen {
+  display: flex;
+}
+
+@media (min-width: 1100px) {
+  .detaljer {
+    display: flex;
+    flex-direction: row;
+    gap: var(--ax-space-24);
+  }
+}
+
+.historikkKnappDesktop {
+  display: none;
+}
+
+@media (min-width: 1100px) {
+  .historikkKnappDesktop {
+    display: block;
+    margin-left: auto;
+  }
+}
+
+.knappContainerMobil {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-12);
+}
+
+@media (min-width: 1100px) {
+  .knappContainerMobil {
+    display: none;
+  }
+}
+
+.knappContainerDesktop {
+  display: none;
+}
+
+@media (min-width: 1100px) {
+  .knappContainerDesktop {
+    display: flex;
+    gap: var(--ax-space-8);
+    margin-left: auto;
+  }
 }
 
 .infoElement {
@@ -34,12 +142,13 @@
   align-items: center;
   gap: var(--ax-space-8);
   white-space: nowrap;
+  flex-wrap: wrap;
 }
 
-.navnContainer {
-  display: flex;
-  align-items: center;
-  gap: var(--ax-space-8);
+@media (min-width: 1100px) {
+  .infoElement {
+    flex-wrap: nowrap;
+  }
 }
 
 .iconContainer {

--- a/app/components/personlinje/personlinje.module.css
+++ b/app/components/personlinje/personlinje.module.css
@@ -102,17 +102,6 @@
   }
 }
 
-.historikkKnappDesktop {
-  display: none;
-}
-
-@media (min-width: 1100px) {
-  .historikkKnappDesktop {
-    display: block;
-    margin-left: auto;
-  }
-}
-
 .knappContainerMobil {
   display: flex;
   flex-direction: column;

--- a/app/components/personlinje/personlinje.module.css
+++ b/app/components/personlinje/personlinje.module.css
@@ -27,7 +27,7 @@
 
 .personlinje {
   display: flex;
-  gap: var(--ax-space-24);
+  gap: var(--ax-space-20);
   align-items: flex-start;
   flex: 1;
   flex-direction: column;
@@ -37,10 +37,11 @@
   .personlinje {
     flex-direction: row;
     align-items: center;
+    gap: var(--ax-space-24);
   }
 }
 
-.navnContainer {
+.navnContainerMobil {
   display: flex;
   align-items: center;
   gap: var(--ax-space-8);
@@ -54,21 +55,27 @@
   font-family: inherit;
 }
 
-.navnContainer:focus-visible {
+.navnContainerMobil:focus-visible {
   outline: 2px solid var(--ax-focus-color, #0067c5);
   outline-offset: 2px;
   border-radius: var(--ax-radius-small);
 }
 
 @media (min-width: 1100px) {
-  .navnContainer {
-    width: auto;
-    cursor: default;
-    pointer-events: none;
+  .navnContainerMobil {
+    display: none;
   }
+}
 
-  .navnContainer:focus-visible {
-    outline: none;
+.navnContainerDesktop {
+  display: none;
+  align-items: center;
+  gap: var(--ax-space-8);
+}
+
+@media (min-width: 1100px) {
+  .navnContainerDesktop {
+    display: flex;
   }
 }
 
@@ -87,7 +94,7 @@
 .detaljer {
   display: none;
   flex-direction: column;
-  gap: var(--ax-space-12);
+  gap: var(--ax-space-16);
 }
 
 .detaljerOpen {
@@ -105,7 +112,7 @@
 .knappContainerMobil {
   display: flex;
   flex-direction: column;
-  gap: var(--ax-space-12);
+  gap: var(--ax-space-16);
 }
 
 @media (min-width: 1100px) {

--- a/app/sanity/fellesKomponenter/personlinje/queries.ts
+++ b/app/sanity/fellesKomponenter/personlinje/queries.ts
@@ -6,5 +6,6 @@ export const personlinjeQuery = groq`*[_type == "meldekortPersonlinje"][0]{
   ageLabel,
   genderLabel,
   citizenshipLabel,
-  historyButton
+  historyButton,
+  createReportCardButton
 }`;

--- a/app/sanity/fellesKomponenter/personlinje/types.ts
+++ b/app/sanity/fellesKomponenter/personlinje/types.ts
@@ -5,4 +5,5 @@ export interface IMeldekortPersonlinje {
   genderLabel: string;
   citizenshipLabel: string;
   historyButton: string;
+  createReportCardButton: string;
 }

--- a/app/sanity/fetchGlobalData.test.ts
+++ b/app/sanity/fetchGlobalData.test.ts
@@ -48,6 +48,7 @@ describe("fetchGlobalSanityData", () => {
     genderLabel: "Kjønn",
     citizenshipLabel: "Statsborgerskap",
     historyButton: "Historikk",
+    createReportCardButton: "Opprett meldekort",
   };
 
   const mockBekreftModalData: IMeldekortBekreftModal = {

--- a/app/utils/env.utils.ts
+++ b/app/utils/env.utils.ts
@@ -48,3 +48,5 @@ export const isLocalhost = getEnv("IS_LOCALHOST") === "true";
 export const usesMsw = getEnv("USE_MSW") === "true";
 
 export const isLocalOrDemo = isLocalhost || usesMsw;
+
+export const showOpprettMeldekortManuelt = isLocalhost || usesMsw;


### PR DESCRIPTION
## Beskrivelse
Knappen for å opprette meldekort manuelt legges på personlinjen, det ble oppdaget at denne ikke tar hensyn til ulike størrelser for vinduet - det blir justert for her, sammen med at knappen legges til. Det er også opprettet nytt felt i sanity, som henter teksten til knappen.

figma:
<img width="1218" height="325" alt="Screenshot 2026-05-27 at 10 10 17" src="https://github.com/user-attachments/assets/a1bd6783-c494-42f1-9e0b-219de1fbbfbb" />

desktop i localhost:
<img width="1919" height="303" alt="Screenshot 2026-05-27 at 10 11 29" src="https://github.com/user-attachments/assets/76b49efc-3d5b-49c0-bb1f-9efe6f3a7752" />

mobil:
<img width="499" height="303" alt="Screenshot 2026-05-27 at 10 11 53" src="https://github.com/user-attachments/assets/dad7b436-535d-48b2-8187-ff1e05b2ea10" />
<img width="499" height="373" alt="Screenshot 2026-05-27 at 10 12 12" src="https://github.com/user-attachments/assets/15372e49-2b26-4d29-960f-b0e3cf86d334" />


## Type endring
- [ ] Bugfix
- [x] Ny funksjonalitet
- [ ] Refaktorering
- [ ] Dokumentasjon
- [ ] Annet

## Sjekkliste
- [x] Koden bygger uten feil (`pnpm run build`)
- [x] Tester er lagt til/oppdatert
- [x] Alle tester passerer (`pnpm test`)
- [ ] README/dokumentasjon er oppdatert (hvis relevant)
