### PR TITLE
lag ui for å opprette meldekort manuelt

### DIFF
--- a/app/components/personlinje/Personlinje.test.tsx
+++ b/app/components/personlinje/Personlinje.test.tsx
@@ -1,0 +1,244 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SaksbehandlerProvider } from "~/context/saksbehandler-context";
+import type { IPerson } from "~/utils/types";
+
+import Personlinje from "./Personlinje";
+
+// Mock the environment utils to control feature flag
+vi.mock("~/utils/env.utils", () => ({
+  showOpprettMeldekortManuelt: false,
+}));
+
+// Helper function to render with required providers
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<SaksbehandlerProvider>{ui}</SaksbehandlerProvider>);
+}
+
+const mockPerson: IPerson = {
+  ansvarligSystem: "DP",
+  fornavn: "Ola",
+  mellomnavn: "Mellomnavn",
+  etternavn: "Nordmann",
+  kjonn: "MANN",
+  ident: "12345678901",
+  fodselsdato: "1990-01-01",
+  statsborgerskap: "NOR",
+};
+
+describe("Personlinje", () => {
+  it("skal vise brukerens navn", () => {
+    renderWithProviders(<Personlinje person={mockPerson} />);
+
+    // Should appear in both mobile and desktop containers
+    const nameElements = screen.getAllByText("Ola Mellomnavn Nordmann");
+    expect(nameElements.length).toBe(2);
+  });
+
+  it("skal vise fødselsnummer", () => {
+    renderWithProviders(<Personlinje person={mockPerson} />);
+
+    expect(screen.getByText("12345678901")).toBeInTheDocument();
+  });
+
+  it("skal vise kopier-knapp for fødselsnummer", () => {
+    renderWithProviders(<Personlinje person={mockPerson} />);
+
+    const copyButton = screen.getByRole("button", { name: /kopier/i });
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it("skal åpne historikk modal når historikk-knappen klikkes på desktop", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Personlinje person={mockPerson} />);
+
+    const historikkButtons = screen.getAllByRole("button", { name: "Historikk" });
+    // Desktop button should exist
+    expect(historikkButtons.length).toBeGreaterThan(0);
+
+    // Click the first historikk button (could be mobile or desktop depending on viewport)
+    await user.click(historikkButtons[0]);
+
+    // Modal should open
+    expect(screen.getByRole("dialog", { name: "Historikk" })).toBeInTheDocument();
+  });
+
+  it("skal lukke historikk modal når lukk-knappen klikkes", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Personlinje person={mockPerson} />);
+
+    const historikkButtons = screen.getAllByRole("button", { name: "Historikk" });
+    await user.click(historikkButtons[0]);
+
+    // Modal should be open
+    expect(screen.getByRole("dialog", { name: "Historikk" })).toBeInTheDocument();
+
+    // Close the modal
+    const closeButton = screen.getByRole("button", { name: /lukk/i });
+    await user.click(closeButton);
+
+    // Modal should be closed
+    expect(screen.queryByRole("dialog", { name: "Historikk" })).not.toBeInTheDocument();
+  });
+
+  describe("Opprett meldekort feature flag", () => {
+    it("skal ikke vise opprett meldekort knapp når feature flag er av", () => {
+      renderWithProviders(<Personlinje person={mockPerson} />);
+
+      expect(screen.queryByRole("button", { name: "Opprett meldekort" })).not.toBeInTheDocument();
+    });
+
+    it("skal vise opprett meldekort knapp når feature flag er på", async () => {
+      // Re-mock with feature flag enabled
+      vi.resetModules();
+      vi.doMock("~/utils/env.utils", () => ({
+        showOpprettMeldekortManuelt: true,
+      }));
+
+      const { showOpprettMeldekortManuelt } = await import("~/utils/env.utils");
+
+      // Verify mock is working
+      expect(showOpprettMeldekortManuelt).toBe(true);
+
+      // Re-import component after mock
+      const PersonlinjeModule = await import("./Personlinje");
+      const PersonlinjeWithFlag = PersonlinjeModule.default;
+
+      renderWithProviders(<PersonlinjeWithFlag person={mockPerson} />);
+
+      const opprettButtons = screen.queryAllByRole("button", { name: "Opprett meldekort" });
+      expect(opprettButtons.length).toBeGreaterThan(0);
+    });
+
+    it("skal åpne opprett meldekort modal når knappen klikkes", async () => {
+      // Re-mock with feature flag enabled
+      vi.resetModules();
+      vi.doMock("~/utils/env.utils", () => ({
+        showOpprettMeldekortManuelt: true,
+      }));
+
+      // Re-import component after mock
+      const PersonlinjeModule = await import("./Personlinje");
+      const PersonlinjeWithFlag = PersonlinjeModule.default;
+
+      const user = userEvent.setup();
+      renderWithProviders(<PersonlinjeWithFlag person={mockPerson} />);
+
+      const opprettButtons = screen.getAllByRole("button", { name: "Opprett meldekort" });
+      await user.click(opprettButtons[0]);
+
+      // Modal should open with user's name
+      const dialog = screen.getByRole("dialog", { name: "Opprett meldekort" });
+      expect(dialog).toBeInTheDocument();
+    });
+
+    it("skal lukke opprett meldekort modal når avbryt klikkes", async () => {
+      // Re-mock with feature flag enabled
+      vi.resetModules();
+      vi.doMock("~/utils/env.utils", () => ({
+        showOpprettMeldekortManuelt: true,
+      }));
+
+      // Re-import component after mock
+      const PersonlinjeModule = await import("./Personlinje");
+      const PersonlinjeWithFlag = PersonlinjeModule.default;
+
+      const user = userEvent.setup();
+      renderWithProviders(<PersonlinjeWithFlag person={mockPerson} />);
+
+      // Open modal
+      const opprettButtons = screen.getAllByRole("button", { name: "Opprett meldekort" });
+      await user.click(opprettButtons[0]);
+
+      expect(screen.getByRole("dialog", { name: "Opprett meldekort" })).toBeInTheDocument();
+
+      // Close modal
+      const avbrytButton = screen.getByRole("button", { name: "Avbryt" });
+      await user.click(avbrytButton);
+
+      expect(screen.queryByRole("dialog", { name: "Opprett meldekort" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Accordion behavior på mobil", () => {
+    it("skal toggle detaljer når navn-knappen klikkes på mobil", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Personlinje person={mockPerson} />);
+
+      // Find the mobile name button (there are two navnContainer, one for mobile, one for desktop)
+      const nameButtons = screen.getAllByRole("button", {
+        name: /ola mellomnavn nordmann/i,
+      });
+
+      // The mobile button should exist (even if hidden by CSS)
+      expect(nameButtons.length).toBeGreaterThan(0);
+
+      // Click to expand
+      await user.click(nameButtons[0]);
+
+      // Details should be visible (aria-expanded should be true)
+      expect(nameButtons[0]).toHaveAttribute("aria-expanded", "true");
+
+      // Click again to collapse
+      await user.click(nameButtons[0]);
+
+      expect(nameButtons[0]).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  describe("Responsiv design", () => {
+    it("skal ha både mobil og desktop navn-containere", () => {
+      const { container } = renderWithProviders(<Personlinje person={mockPerson} />);
+
+      // Should have navnContainerMobil class
+      const mobilContainer = container.querySelector('[class*="navnContainerMobil"]');
+      expect(mobilContainer).toBeInTheDocument();
+
+      // Should have navnContainerDesktop class
+      const desktopContainer = container.querySelector('[class*="navnContainerDesktop"]');
+      expect(desktopContainer).toBeInTheDocument();
+    });
+
+    it("skal ha både mobil og desktop knapp-containere", () => {
+      const { container } = renderWithProviders(<Personlinje person={mockPerson} />);
+
+      // Should have knappContainerMobil class
+      const mobilKnapper = container.querySelector('[class*="knappContainerMobil"]');
+      expect(mobilKnapper).toBeInTheDocument();
+
+      // Should have knappContainerDesktop class
+      const desktopKnapper = container.querySelector('[class*="knappContainerDesktop"]');
+      expect(desktopKnapper).toBeInTheDocument();
+    });
+  });
+
+  describe("Maskerte data", () => {
+    it("skal ikke vise kopier-knapp for maskerte data", () => {
+      const maskedPerson: IPerson = {
+        ...mockPerson,
+        fornavn: "•••••",
+        etternavn: "•••••",
+        ident: "•••••••••••",
+      };
+
+      renderWithProviders(<Personlinje person={maskedPerson} />);
+
+      expect(screen.queryByRole("button", { name: /kopier/i })).not.toBeInTheDocument();
+    });
+
+    it("skal vise sensitiv styling for maskerte data", () => {
+      const maskedPerson: IPerson = {
+        ...mockPerson,
+        fornavn: "•••••",
+        etternavn: "•••••",
+      };
+
+      const { container } = renderWithProviders(<Personlinje person={maskedPerson} />);
+
+      const sensitivElements = container.querySelectorAll('[class*="sensitiv"]');
+      expect(sensitivElements.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/components/personlinje/Personlinje.test.tsx
+++ b/app/components/personlinje/Personlinje.test.tsx
@@ -7,12 +7,10 @@ import type { IPerson } from "~/utils/types";
 
 import Personlinje from "./Personlinje";
 
-// Mock the environment utils to control feature flag
 vi.mock("~/utils/env.utils", () => ({
   showOpprettMeldekortManuelt: false,
 }));
 
-// Helper function to render with required providers
 function renderWithProviders(ui: React.ReactElement) {
   return render(<SaksbehandlerProvider>{ui}</SaksbehandlerProvider>);
 }
@@ -32,7 +30,6 @@ describe("Personlinje", () => {
   it("skal vise brukerens navn", () => {
     renderWithProviders(<Personlinje person={mockPerson} />);
 
-    // Should appear in both mobile and desktop containers
     const nameElements = screen.getAllByText("Ola Mellomnavn Nordmann");
     expect(nameElements.length).toBe(2);
   });
@@ -55,13 +52,10 @@ describe("Personlinje", () => {
     renderWithProviders(<Personlinje person={mockPerson} />);
 
     const historikkButtons = screen.getAllByRole("button", { name: "Historikk" });
-    // Desktop button should exist
     expect(historikkButtons.length).toBeGreaterThan(0);
 
-    // Click the first historikk button (could be mobile or desktop depending on viewport)
     await user.click(historikkButtons[0]);
 
-    // Modal should open
     expect(screen.getByRole("dialog", { name: "Historikk" })).toBeInTheDocument();
   });
 
@@ -72,37 +66,41 @@ describe("Personlinje", () => {
     const historikkButtons = screen.getAllByRole("button", { name: "Historikk" });
     await user.click(historikkButtons[0]);
 
-    // Modal should be open
     expect(screen.getByRole("dialog", { name: "Historikk" })).toBeInTheDocument();
 
-    // Close the modal
     const closeButton = screen.getByRole("button", { name: /lukk/i });
     await user.click(closeButton);
 
-    // Modal should be closed
     expect(screen.queryByRole("dialog", { name: "Historikk" })).not.toBeInTheDocument();
   });
 
   describe("Opprett meldekort feature flag", () => {
-    it("skal ikke vise opprett meldekort knapp når feature flag er av", () => {
-      renderWithProviders(<Personlinje person={mockPerson} />);
+    it("skal ikke vise opprett meldekort knapp når feature flag er av", async () => {
+      vi.resetModules();
+      vi.doMock("~/utils/env.utils", () => ({
+        showOpprettMeldekortManuelt: false,
+      }));
+
+      const { showOpprettMeldekortManuelt } = await import("~/utils/env.utils");
+      expect(showOpprettMeldekortManuelt).toBe(false);
+
+      const PersonlinjeModule = await import("./Personlinje");
+      const PersonlinjeWithoutFlag = PersonlinjeModule.default;
+
+      renderWithProviders(<PersonlinjeWithoutFlag person={mockPerson} />);
 
       expect(screen.queryByRole("button", { name: "Opprett meldekort" })).not.toBeInTheDocument();
     });
 
     it("skal vise opprett meldekort knapp når feature flag er på", async () => {
-      // Re-mock with feature flag enabled
       vi.resetModules();
       vi.doMock("~/utils/env.utils", () => ({
         showOpprettMeldekortManuelt: true,
       }));
 
       const { showOpprettMeldekortManuelt } = await import("~/utils/env.utils");
-
-      // Verify mock is working
       expect(showOpprettMeldekortManuelt).toBe(true);
 
-      // Re-import component after mock
       const PersonlinjeModule = await import("./Personlinje");
       const PersonlinjeWithFlag = PersonlinjeModule.default;
 
@@ -113,13 +111,11 @@ describe("Personlinje", () => {
     });
 
     it("skal åpne opprett meldekort modal når knappen klikkes", async () => {
-      // Re-mock with feature flag enabled
       vi.resetModules();
       vi.doMock("~/utils/env.utils", () => ({
         showOpprettMeldekortManuelt: true,
       }));
 
-      // Re-import component after mock
       const PersonlinjeModule = await import("./Personlinje");
       const PersonlinjeWithFlag = PersonlinjeModule.default;
 
@@ -129,32 +125,27 @@ describe("Personlinje", () => {
       const opprettButtons = screen.getAllByRole("button", { name: "Opprett meldekort" });
       await user.click(opprettButtons[0]);
 
-      // Modal should open with user's name
       const dialog = screen.getByRole("dialog", { name: "Opprett meldekort" });
       expect(dialog).toBeInTheDocument();
     });
 
     it("skal lukke opprett meldekort modal når avbryt klikkes", async () => {
-      // Re-mock with feature flag enabled
       vi.resetModules();
       vi.doMock("~/utils/env.utils", () => ({
         showOpprettMeldekortManuelt: true,
       }));
 
-      // Re-import component after mock
       const PersonlinjeModule = await import("./Personlinje");
       const PersonlinjeWithFlag = PersonlinjeModule.default;
 
       const user = userEvent.setup();
       renderWithProviders(<PersonlinjeWithFlag person={mockPerson} />);
 
-      // Open modal
       const opprettButtons = screen.getAllByRole("button", { name: "Opprett meldekort" });
       await user.click(opprettButtons[0]);
 
       expect(screen.getByRole("dialog", { name: "Opprett meldekort" })).toBeInTheDocument();
 
-      // Close modal
       const avbrytButton = screen.getByRole("button", { name: "Avbryt" });
       await user.click(avbrytButton);
 
@@ -167,21 +158,16 @@ describe("Personlinje", () => {
       const user = userEvent.setup();
       renderWithProviders(<Personlinje person={mockPerson} />);
 
-      // Find the mobile name button (there are two navnContainer, one for mobile, one for desktop)
       const nameButtons = screen.getAllByRole("button", {
         name: /ola mellomnavn nordmann/i,
       });
 
-      // The mobile button should exist (even if hidden by CSS)
       expect(nameButtons.length).toBeGreaterThan(0);
 
-      // Click to expand
       await user.click(nameButtons[0]);
 
-      // Details should be visible (aria-expanded should be true)
       expect(nameButtons[0]).toHaveAttribute("aria-expanded", "true");
 
-      // Click again to collapse
       await user.click(nameButtons[0]);
 
       expect(nameButtons[0]).toHaveAttribute("aria-expanded", "false");
@@ -192,11 +178,9 @@ describe("Personlinje", () => {
     it("skal ha både mobil og desktop navn-containere", () => {
       const { container } = renderWithProviders(<Personlinje person={mockPerson} />);
 
-      // Should have navnContainerMobil class
       const mobilContainer = container.querySelector('[class*="navnContainerMobil"]');
       expect(mobilContainer).toBeInTheDocument();
 
-      // Should have navnContainerDesktop class
       const desktopContainer = container.querySelector('[class*="navnContainerDesktop"]');
       expect(desktopContainer).toBeInTheDocument();
     });
@@ -204,11 +188,9 @@ describe("Personlinje", () => {
     it("skal ha både mobil og desktop knapp-containere", () => {
       const { container } = renderWithProviders(<Personlinje person={mockPerson} />);
 
-      // Should have knappContainerMobil class
       const mobilKnapper = container.querySelector('[class*="knappContainerMobil"]');
       expect(mobilKnapper).toBeInTheDocument();
 
-      // Should have knappContainerDesktop class
       const desktopKnapper = container.querySelector('[class*="knappContainerDesktop"]');
       expect(desktopKnapper).toBeInTheDocument();
     });

--- a/app/components/personlinje/Personlinje.tsx
+++ b/app/components/personlinje/Personlinje.tsx
@@ -19,6 +19,7 @@ import {
   transformPerioderToHistoryEvents,
 } from "../../modals/historikk/historikk.utils";
 import { HistorikkModal } from "../../modals/historikk/HistorikkModal";
+import { OpprettMeldekortModal } from "../../modals/opprett-meldekort/OpprettMeldekortModal";
 import { beregnAlder, erKvinne, erMann, getKjonnKlasse } from "./Personlinje.helpers";
 import styles from "./personlinje.module.css";
 
@@ -48,6 +49,7 @@ export default function Personlinje({
 }: IProps) {
   const fulltNavn = byggFulltNavn(person.fornavn, person.mellomnavn, person.etternavn);
   const [modalOpen, setModalOpen] = useState(false);
+  const [opprettModalOpen, setOpprettModalOpen] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
   // Sjekk om data er maskert (kommer fra server-side maskering)
@@ -164,7 +166,12 @@ export default function Personlinje({
             </div>
             {showOpprettMeldekortManuelt && (
               <div>
-                <Button data-color="neutral" variant="secondary" size="xsmall">
+                <Button
+                  data-color="neutral"
+                  variant="secondary"
+                  size="xsmall"
+                  onClick={() => setOpprettModalOpen(true)}
+                >
                   {texts.createReportCardButton}
                 </Button>
               </div>
@@ -182,12 +189,22 @@ export default function Personlinje({
           {texts.historyButton}
         </Button>
         {showOpprettMeldekortManuelt && (
-          <Button data-color="neutral" variant="secondary" size="small">
+          <Button
+            data-color="neutral"
+            variant="secondary"
+            size="small"
+            onClick={() => setOpprettModalOpen(true)}
+          >
             {texts.createReportCardButton}
           </Button>
         )}
       </div>
       <HistorikkModal open={modalOpen} onClose={() => setModalOpen(false)} hendelser={events} />
+      <OpprettMeldekortModal
+        open={opprettModalOpen}
+        onClose={() => setOpprettModalOpen(false)}
+        brukerNavn={fulltNavn}
+      />
     </section>
   );
 }

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SaksbehandlerProvider } from "~/context/saksbehandler-context";
+
+import { OpprettMeldekortModal } from "./OpprettMeldekortModal";
+
+// Helper function to render with required providers
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<SaksbehandlerProvider>{ui}</SaksbehandlerProvider>);
+}
+
+describe("OpprettMeldekortModal", () => {
+  it("skal rendre modal når open er true", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Opprett meldekort" })).toBeInTheDocument();
+    expect(screen.getByText("Opprett meldekort")).toBeInTheDocument();
+  });
+
+  it("skal ikke rendre modal når open er false", () => {
+    renderWithProviders(<OpprettMeldekortModal open={false} onClose={vi.fn()} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("skal kalle onClose når modal lukkes", async () => {
+    const user = userEvent.setup();
+    const onCloseMock = vi.fn();
+
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={onCloseMock} />);
+
+    const closeButton = screen.getByRole("button", { name: /lukk/i });
+    await user.click(closeButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skal kalle onClose når avbryt-knappen klikkes", async () => {
+    const user = userEvent.setup();
+    const onCloseMock = vi.fn();
+
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={onCloseMock} />);
+
+    const avbrytButton = screen.getByRole("button", { name: "Avbryt" });
+    await user.click(avbrytButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skal vise fra-dato og til-dato input felter", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText("Fra dato")).toBeInTheDocument();
+    expect(screen.getByLabelText("Til dato")).toBeInTheDocument();
+  });
+
+  it("skal vise info-boks med informasjon om meldekortsyklus", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Info om meldekortsyklus")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Nye meldekort opprettes i samme syklus som den bruker allerede har. Meldekort opprettes hver 14. dag.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("skal vise opprett-knapp", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    const opprettButton = screen.getByRole("button", { name: "Opprett" });
+    expect(opprettButton).toBeInTheDocument();
+  });
+
+  it("skal kalle onBekreft og onClose når opprett-knappen klikkes", async () => {
+    const user = userEvent.setup();
+    const onBekreftMock = vi.fn();
+    const onCloseMock = vi.fn();
+
+    renderWithProviders(
+      <OpprettMeldekortModal open={true} onClose={onCloseMock} onBekreft={onBekreftMock} />,
+    );
+
+    const opprettButton = screen.getByRole("button", { name: "Opprett" });
+    await user.click(opprettButton);
+
+    expect(onBekreftMock).toHaveBeenCalledTimes(1);
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skal vise brukernavn i tittel når det er oppgitt", () => {
+    renderWithProviders(
+      <OpprettMeldekortModal open={true} onClose={vi.fn()} brukerNavn="Ola Nordmann" />,
+    );
+
+    // Assuming the title template uses {{navn}} placeholder
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("skal ha korrekt aria-label på modal", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-label", "Opprett meldekort");
+  });
+
+  it("skal ha medium størrelse på modal", () => {
+    const { container } = renderWithProviders(
+      <OpprettMeldekortModal open={true} onClose={vi.fn()} />,
+    );
+
+    const modalContent = container.querySelector('[class*="modal"]');
+    expect(modalContent).toBeInTheDocument();
+  });
+
+  it("skal ikke kalle onBekreft hvis det ikke er definert", async () => {
+    const user = userEvent.setup();
+    const onCloseMock = vi.fn();
+
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={onCloseMock} />);
+
+    const opprettButton = screen.getByRole("button", { name: "Opprett" });
+    await user.click(opprettButton);
+
+    // Should only close, not throw error
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skal vise hjelpetekst for fra-dato felt", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText("Velg startdato for perioden du vil opprette meldekort for"),
+    ).toBeInTheDocument();
+  });
+
+  it("skal vise hjelpetekst for til-dato felt", () => {
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText("Velg sluttdato for perioden du vil opprette meldekort for"),
+    ).toBeInTheDocument();
+  });
+
+  describe("DatePicker integration", () => {
+    it("skal bruke useRangeDatepicker for dato-valg", () => {
+      renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
+
+      // Verify that both date inputs are present and part of a range picker
+      const fromInput = screen.getByLabelText("Fra dato");
+      const toInput = screen.getByLabelText("Til dato");
+
+      expect(fromInput).toBeInTheDocument();
+      expect(toInput).toBeInTheDocument();
+    });
+  });
+});

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -1,0 +1,134 @@
+import {
+  BodyShort,
+  Button,
+  DatePicker,
+  InfoCard,
+  Modal,
+  useRangeDatepicker,
+  VStack,
+} from "@navikt/ds-react";
+import { useRouteLoaderData } from "react-router";
+
+import type { IMeldekortOpprettMeldekortModal } from "~/sanity/modaler/opprett-meldekort-modal/types";
+import { deepMerge } from "~/utils/deep-merge.utils";
+
+import styles from "./opprettMeldekortModal.module.css";
+
+// Default tekster som fallback hvis Sanity-data ikke er tilgjengelig
+const DEFAULT_TEKSTER: IMeldekortOpprettMeldekortModal = {
+  tittel: "Opprett meldekort",
+  fraDato: {
+    label: "Fra dato",
+    helpText: "Velg startdato for perioden du vil opprette meldekort for",
+  },
+  tilDato: {
+    label: "Til dato",
+    helpText: "Velg sluttdato for perioden du vil opprette meldekort for",
+  },
+  forklaringstekst: "Basert på valgt dato, vil det opprettes {{antall}} nye meldekort.",
+  submitKnapp: "Opprett",
+  avbrytKnapp: "Avbryt",
+  infoBoks: {
+    tittel: "Info om meldekortsyklus",
+    tekst:
+      "Nye meldekort opprettes i samme syklus som den bruker allerede har. Meldekort opprettes hver 14. dag.",
+  },
+  feilmelding: {
+    tittel: "Kunne ikke opprette meldekort",
+    tekst: "Noe gikk galt ved opprettelse av meldekort. Prøv igjen senere.",
+  },
+};
+
+interface OpprettMeldekortModalProps {
+  open: boolean;
+  onClose: () => void;
+  onBekreft?: () => void;
+  brukerNavn?: string;
+}
+
+export function OpprettMeldekortModal({
+  open,
+  onClose,
+  onBekreft,
+  brukerNavn,
+}: OpprettMeldekortModalProps) {
+  // Hent tekster fra Sanity med fallback
+  let rootData;
+  try {
+    rootData = useRouteLoaderData("root");
+  } catch {
+    rootData = null;
+  }
+
+  const tekster = deepMerge(DEFAULT_TEKSTER, rootData?.sanity?.opprettMeldekortModal);
+
+  const { datepickerProps, fromInputProps, toInputProps, reset } = useRangeDatepicker({
+    fromDate: undefined,
+    toDate: undefined,
+  });
+
+  function handleBekreft() {
+    if (onBekreft) {
+      onBekreft();
+    }
+    handleClose();
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  const tittelMedNavn = brukerNavn
+    ? tekster.tittel.replace("{{navn}}", brukerNavn)
+    : tekster.tittel;
+
+  return (
+    <Modal open={open} onClose={handleClose} aria-label={tittelMedNavn} size="medium">
+      <Modal.Header>
+        <h2>{tittelMedNavn}</h2>
+      </Modal.Header>
+      <Modal.Body>
+        <div className={styles.content}>
+          <DatePicker {...datepickerProps}>
+            <VStack gap="space-16">
+              <DatePicker.Input
+                size="small"
+                {...fromInputProps}
+                label={tekster.fraDato.label}
+                description={tekster.fraDato.helpText}
+              />
+              <DatePicker.Input
+                size="small"
+                {...toInputProps}
+                label={tekster.tilDato.label}
+                description={tekster.tilDato.helpText}
+              />
+            </VStack>
+          </DatePicker>
+          <BodyShort>{tekster.forklaringstekst}</BodyShort>
+          <InfoCard data-color="info" size="small">
+            <InfoCard.Header>
+              <InfoCard.Title>{tekster.infoBoks.tittel}</InfoCard.Title>
+            </InfoCard.Header>
+            <InfoCard.Content>{tekster.infoBoks.tekst}</InfoCard.Content>
+          </InfoCard>
+          <InfoCard data-color="danger" size="small">
+            <InfoCard.Header>
+              <InfoCard.Title>{tekster.feilmelding.tittel}</InfoCard.Title>
+            </InfoCard.Header>
+            <InfoCard.Content>{tekster.feilmelding.tekst}</InfoCard.Content>
+          </InfoCard>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="primary" onClick={handleBekreft} size="small">
+          {tekster.submitKnapp}
+        </Button>
+        <Button variant="secondary" onClick={handleClose} size="small">
+          {tekster.avbrytKnapp}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.module.css
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.module.css
@@ -1,0 +1,5 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-24);
+}

--- a/app/sanity/fetchGlobalData.test.ts
+++ b/app/sanity/fetchGlobalData.test.ts
@@ -10,6 +10,7 @@ import type { IMeldekortVarsler } from "./fellesKomponenter/varsler/types";
 import { fetchGlobalSanityData } from "./fetchGlobalData";
 import type { IMeldekortBekreftModal } from "./modaler/bekreft-modal/types";
 import type { IMeldekortHistorikkModal } from "./modaler/historikk-modal/types";
+import type { IMeldekortOpprettMeldekortModal } from "./modaler/opprett-meldekort-modal/types";
 
 // Mock sanityClient
 vi.mock("./client", () => ({
@@ -99,6 +100,29 @@ describe("fetchGlobalSanityData", () => {
       ingenData: "Fant hverken meldekort eller arbeidssøkerstatus knyttet til denne personen",
       ingenMeldekort: "Fant ingen meldekort knyttet til denne personen",
       ingenStatus: "Fant ingen arbeidssøkerstatus knyttet til denne personen",
+    },
+  };
+
+  const mockOpprettMeldekortModalData: IMeldekortOpprettMeldekortModal = {
+    tittel: "Opprett meldekort",
+    fraDato: {
+      label: "Fra dato",
+      helpText: "Velg startdato",
+    },
+    tilDato: {
+      label: "Til dato",
+      helpText: "Velg sluttdato",
+    },
+    forklaringstekst: "Basert på valgt dato, vil det opprettes {{antall}} nye meldekort.",
+    submitKnapp: "Opprett",
+    avbrytKnapp: "Avbryt",
+    infoBoks: {
+      tittel: "Info",
+      tekst: "Nye meldekort opprettes hver 14. dag.",
+    },
+    feilmelding: {
+      tittel: "Feil",
+      tekst: "Kunne ikke opprette meldekort.",
     },
   };
 
@@ -202,6 +226,7 @@ describe("fetchGlobalSanityData", () => {
       .mockResolvedValueOnce(mockPersonlinjeData as never)
       .mockResolvedValueOnce(mockBekreftModalData as never)
       .mockResolvedValueOnce(mockHistorikkModalData as never)
+      .mockResolvedValueOnce(mockOpprettMeldekortModalData as never)
       .mockResolvedValueOnce(mockAktiviteterData as never)
       .mockResolvedValueOnce(mockStatuserData as never)
       .mockResolvedValueOnce(mockKalenderData as never)
@@ -215,13 +240,14 @@ describe("fetchGlobalSanityData", () => {
       personlinje: mockPersonlinjeData,
       bekreftModal: mockBekreftModalData,
       historikkModal: mockHistorikkModalData,
+      opprettMeldekortModal: mockOpprettMeldekortModalData,
       aktiviteter: mockAktiviteterData,
       statuser: mockStatuserData,
       kalender: mockKalenderData,
       varsler: mockVarslerData,
       aktivitetstabell: mockAktivitetstabellData,
     });
-    expect(sanityClient.fetch).toHaveBeenCalledTimes(9);
+    expect(sanityClient.fetch).toHaveBeenCalledTimes(10);
   });
 
   it("skal returnere null-verdier ved feil", async () => {
@@ -237,6 +263,7 @@ describe("fetchGlobalSanityData", () => {
       personlinje: null,
       bekreftModal: null,
       historikkModal: null,
+      opprettMeldekortModal: null,
       aktiviteter: null,
       statuser: null,
       kalender: null,
@@ -244,7 +271,7 @@ describe("fetchGlobalSanityData", () => {
       aktivitetstabell: null,
     });
     // Med Promise.allSettled logges hver feilende query individuelt
-    expect(logger.warn).toHaveBeenCalledTimes(9);
+    expect(logger.warn).toHaveBeenCalledTimes(10);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Sanity query"), {
       queryName: expect.any(String),
       error: expect.any(Error),
@@ -264,13 +291,14 @@ describe("fetchGlobalSanityData", () => {
       personlinje: null,
       bekreftModal: null,
       historikkModal: null,
+      opprettMeldekortModal: null,
       aktiviteter: null,
       statuser: null,
       kalender: null,
       varsler: null,
       aktivitetstabell: null,
     });
-    expect(logger.warn).toHaveBeenCalledTimes(9);
+    expect(logger.warn).toHaveBeenCalledTimes(10);
   });
 
   it("skal kunne håndtere at kun en av fetchene feiler", async () => {
@@ -283,6 +311,7 @@ describe("fetchGlobalSanityData", () => {
       .mockRejectedValueOnce(new Error("Personlinje fetch failed"))
       .mockResolvedValueOnce(mockBekreftModalData as never)
       .mockResolvedValueOnce(mockHistorikkModalData as never)
+      .mockResolvedValueOnce(mockOpprettMeldekortModalData as never)
       .mockResolvedValueOnce(mockAktiviteterData as never)
       .mockResolvedValueOnce(mockStatuserData as never)
       .mockResolvedValueOnce(mockKalenderData as never)
@@ -298,6 +327,7 @@ describe("fetchGlobalSanityData", () => {
       personlinje: null,
       bekreftModal: mockBekreftModalData,
       historikkModal: mockHistorikkModalData,
+      opprettMeldekortModal: mockOpprettMeldekortModalData,
       aktiviteter: mockAktiviteterData,
       statuser: mockStatuserData,
       kalender: mockKalenderData,
@@ -321,6 +351,7 @@ describe("fetchGlobalSanityData", () => {
       .mockResolvedValueOnce(mockPersonlinjeData as never)
       .mockResolvedValueOnce(mockBekreftModalData as never)
       .mockResolvedValueOnce(mockHistorikkModalData as never)
+      .mockResolvedValueOnce(mockOpprettMeldekortModalData as never)
       .mockResolvedValueOnce(mockAktiviteterData as never)
       .mockResolvedValueOnce(mockStatuserData as never)
       .mockResolvedValueOnce(mockKalenderData as never)
@@ -333,6 +364,7 @@ describe("fetchGlobalSanityData", () => {
     expect(result).toHaveProperty("personlinje");
     expect(result).toHaveProperty("bekreftModal");
     expect(result).toHaveProperty("historikkModal");
+    expect(result).toHaveProperty("opprettMeldekortModal");
     expect(result).toHaveProperty("aktiviteter");
     expect(result).toHaveProperty("statuser");
     expect(result).toHaveProperty("kalender");

--- a/app/sanity/fetchGlobalData.ts
+++ b/app/sanity/fetchGlobalData.ts
@@ -19,12 +19,15 @@ import { bekreftModalQuery } from "./modaler/bekreft-modal/queries";
 import type { IMeldekortBekreftModal } from "./modaler/bekreft-modal/types";
 import { historikkModalQuery } from "./modaler/historikk-modal/queries";
 import type { IMeldekortHistorikkModal } from "./modaler/historikk-modal/types";
+import { opprettMeldekortModalQuery } from "./modaler/opprett-meldekort-modal/queries";
+import type { IMeldekortOpprettMeldekortModal } from "./modaler/opprett-meldekort-modal/types";
 
 export interface GlobalSanityData {
   header: IMeldekortHeader | null;
   personlinje: IMeldekortPersonlinje | null;
   bekreftModal: IMeldekortBekreftModal | null;
   historikkModal: IMeldekortHistorikkModal | null;
+  opprettMeldekortModal: IMeldekortOpprettMeldekortModal | null;
   aktiviteter: IMeldekortAktiviteter | null;
   statuser: IMeldekortStatuser | null;
   kalender: IMeldekortKalender | null;
@@ -72,6 +75,7 @@ export async function fetchGlobalSanityData(): Promise<GlobalSanityData> {
     personlinje,
     bekreftModal,
     historikkModal,
+    opprettMeldekortModal,
     aktiviteter,
     statuser,
     kalender,
@@ -87,6 +91,9 @@ export async function fetchGlobalSanityData(): Promise<GlobalSanityData> {
     ),
     fetchQuery("historikkModal", historikkModalQuery, () =>
       sanityClient.fetch<IMeldekortHistorikkModal>(historikkModalQuery),
+    ),
+    fetchQuery("opprettMeldekortModal", opprettMeldekortModalQuery, () =>
+      sanityClient.fetch<IMeldekortOpprettMeldekortModal>(opprettMeldekortModalQuery),
     ),
     fetchQuery("aktiviteter", aktiviteterQuery, () =>
       sanityClient.fetch<IMeldekortAktiviteter>(aktiviteterQuery),
@@ -108,6 +115,7 @@ export async function fetchGlobalSanityData(): Promise<GlobalSanityData> {
     personlinje,
     bekreftModal,
     historikkModal,
+    opprettMeldekortModal,
     aktiviteter,
     statuser,
     kalender,

--- a/app/sanity/modaler/opprett-meldekort-modal/queries.ts
+++ b/app/sanity/modaler/opprett-meldekort-modal/queries.ts
@@ -1,0 +1,24 @@
+import groq from "groq";
+
+export const opprettMeldekortModalQuery = groq`*[_type == "opprettMeldekortModal"][0]{
+  tittel,
+  fraDato {
+    label,
+    helpText
+  },
+  tilDato {
+    label,
+    helpText
+  },
+  forklaringstekst,
+  submitKnapp,
+  avbrytKnapp,
+  infoBoks {
+    tittel,
+    tekst
+  },
+  feilmelding {
+    tittel,
+    tekst
+  }
+}`;

--- a/app/sanity/modaler/opprett-meldekort-modal/types.ts
+++ b/app/sanity/modaler/opprett-meldekort-modal/types.ts
@@ -1,0 +1,25 @@
+export interface IDatoFelt {
+  label: string;
+  helpText: string;
+}
+
+export interface IInfoBoks {
+  tittel: string;
+  tekst: string;
+}
+
+export interface IFeilmelding {
+  tittel: string;
+  tekst: string;
+}
+
+export interface IMeldekortOpprettMeldekortModal {
+  tittel: string;
+  fraDato: IDatoFelt;
+  tilDato: IDatoFelt;
+  forklaringstekst: string;
+  submitKnapp: string;
+  avbrytKnapp: string;
+  infoBoks: IInfoBoks;
+  feilmelding: IFeilmelding;
+}


### PR DESCRIPTION

## Beskrivelse
Oppretter UI  så det er klart for funksjoner
alt av funksjoner og ulike visninger vil styres når logikk legges til

<img width="1363" height="796" alt="Screenshot 2026-05-28 at 08 20 50" src="https://github.com/user-attachments/assets/a70e6e76-9be6-4528-9c9e-684a48336a76" />


## Type endring
- [ ] Bugfix
- [x] Ny funksjonalitet
- [ ] Refaktorering
- [ ] Dokumentasjon
- [ ] Annet

## Sjekkliste
- [ ] Koden bygger uten feil (`pnpm run build`)
- [ ] Tester er lagt til/oppdatert
- [ ] Alle tester passerer (`pnpm test`)
- [ ] README/dokumentasjon er oppdatert (hvis relevant)
