### PR TITLE
RAMP-195 skjule knapp for arena på riktig måte

### DIFF
--- a/app/components/personlinje/Personlinje.test.tsx
+++ b/app/components/personlinje/Personlinje.test.tsx
@@ -38,7 +38,10 @@ const personlinjeData: IMeldekortPersonlinje = {
   genderLabel: "Kjønn:",
   citizenshipLabel: "Statsborgerskap:",
   historyButton: "Historikk",
-  createReportCardButton: "Opprett meldekort",
+  createReportCardButton: {
+    label: "Opprett meldekort",
+    description: "Det kan ikke opprettes meldekort manuelt for brukere i Arena",
+  },
 };
 
 describe("Personlinje", () => {
@@ -194,6 +197,37 @@ describe("Personlinje", () => {
       expect(
         screen.queryByRole("dialog", { name: "[Mangler Sanity: opprettMeldekortModal.tittel]" }),
       ).not.toBeInTheDocument();
+    });
+
+    it("skal deaktivere opprett meldekort knapp for brukere i Arena", () => {
+      renderWithProviders(
+        <Personlinje
+          person={{ ...mockPerson, ansvarligSystem: "ARENA" }}
+          personlinjeData={personlinjeData}
+          visOpprettMeldekort
+        />,
+      );
+
+      screen.getAllByRole("button", { name: "Opprett meldekort" }).forEach((knapp) => {
+        expect(knapp).toBeDisabled();
+      });
+    });
+
+    it("skal vise forklaring når knappen er deaktivert for Arena", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <Personlinje
+          person={{ ...mockPerson, ansvarligSystem: "ARENA" }}
+          personlinjeData={personlinjeData}
+          visOpprettMeldekort
+        />,
+      );
+
+      await user.click(screen.getAllByRole("button", { name: "Mer informasjon" })[0]);
+
+      expect(
+        await screen.findAllByText("Det kan ikke opprettes meldekort manuelt for brukere i Arena"),
+      ).not.toHaveLength(0);
     });
   });
 

--- a/app/components/personlinje/Personlinje.tsx
+++ b/app/components/personlinje/Personlinje.tsx
@@ -4,13 +4,14 @@ import {
   FigureOutwardFillIcon,
   SilhouetteFillIcon,
 } from "@navikt/aksel-icons";
-import { BodyShort, Button, CopyButton } from "@navikt/ds-react";
+import { BodyShort, Button, CopyButton, HelpText } from "@navikt/ds-react";
 import classNames from "classnames";
 import { useMemo, useState } from "react";
 import { useRevalidator } from "react-router";
 
 import type { IMeldekortPersonlinje } from "~/sanity/fellesKomponenter/personlinje/types";
 import { sanityTekst } from "~/sanity/utils";
+import { ANSVARLIG_SYSTEM } from "~/utils/constants";
 import { byggFulltNavn } from "~/utils/person.utils";
 import type { IArbeidssokerperiode, IPerson, IRapporteringsperiode } from "~/utils/types";
 
@@ -57,6 +58,35 @@ export default function Personlinje({
       ...transformPerioderToHistoryEvents(perioder),
     ].sort((a, b) => (a.dato < b.dato ? 1 : -1));
   }, [perioder, arbeidssokerperioder]);
+
+  const erArenaBruker = person.ansvarligSystem === ANSVARLIG_SYSTEM.ARENA;
+
+  function opprettMeldekortKnapp(size: "xsmall" | "small") {
+    return (
+      <div className={styles.opprettMeldekortKnapp}>
+        <Button
+          data-color="neutral"
+          variant="secondary"
+          size={size}
+          disabled={erArenaBruker}
+          onClick={() => setOpprettModalOpen(true)}
+        >
+          {sanityTekst(
+            texts?.createReportCardButton?.label,
+            "personlinje.createReportCardButton.label",
+          )}
+        </Button>
+        {erArenaBruker && (
+          <HelpText placement="left">
+            {sanityTekst(
+              texts?.createReportCardButton?.description,
+              "personlinje.createReportCardButton.description",
+            )}
+          </HelpText>
+        )}
+      </div>
+    );
+  }
 
   return (
     <section
@@ -162,18 +192,7 @@ export default function Personlinje({
                 {sanityTekst(texts?.historyButton, "personlinje.historyButton")}
               </Button>
             </div>
-            {visOpprettMeldekort && (
-              <div>
-                <Button
-                  data-color="neutral"
-                  variant="secondary"
-                  size="xsmall"
-                  onClick={() => setOpprettModalOpen(true)}
-                >
-                  {sanityTekst(texts?.createReportCardButton, "personlinje.createReportCardButton")}
-                </Button>
-              </div>
-            )}
+            {visOpprettMeldekort && <div>{opprettMeldekortKnapp("xsmall")}</div>}
           </div>
         </div>
       </div>
@@ -186,16 +205,7 @@ export default function Personlinje({
         >
           {sanityTekst(texts?.historyButton, "personlinje.historyButton")}
         </Button>
-        {visOpprettMeldekort && (
-          <Button
-            data-color="neutral"
-            variant="secondary"
-            size="small"
-            onClick={() => setOpprettModalOpen(true)}
-          >
-            {sanityTekst(texts?.createReportCardButton, "personlinje.createReportCardButton")}
-          </Button>
-        )}
+        {visOpprettMeldekort && opprettMeldekortKnapp("small")}
       </div>
       <HistorikkModal open={modalOpen} onClose={() => setModalOpen(false)} hendelser={events} />
       <OpprettMeldekortModal

--- a/app/components/personlinje/personlinje.module.css
+++ b/app/components/personlinje/personlinje.module.css
@@ -133,6 +133,13 @@
   }
 }
 
+.opprettMeldekortKnapp {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--ax-space-4);
+}
+
 .infoElement {
   display: flex;
   align-items: center;

--- a/app/sanity/fellesKomponenter/personlinje/queries.ts
+++ b/app/sanity/fellesKomponenter/personlinje/queries.ts
@@ -7,5 +7,8 @@ export const personlinjeQuery = groq`*[_type == "meldekortPersonlinje"][0]{
   genderLabel,
   citizenshipLabel,
   historyButton,
-  createReportCardButton
+  createReportCardButton{
+    label,
+    description
+  }
 }`;

--- a/app/sanity/fellesKomponenter/personlinje/types.ts
+++ b/app/sanity/fellesKomponenter/personlinje/types.ts
@@ -1,3 +1,8 @@
+export interface IMeldekortPersonlinjeKnapp {
+  label: string;
+  description: string;
+}
+
 export interface IMeldekortPersonlinje {
   sectionAriaLabel: string;
   birthNumberLabel: string;
@@ -5,5 +10,5 @@ export interface IMeldekortPersonlinje {
   genderLabel: string;
   citizenshipLabel: string;
   historyButton: string;
-  createReportCardButton: string;
+  createReportCardButton: IMeldekortPersonlinjeKnapp;
 }

--- a/app/sanity/fetchGlobalData.test.ts
+++ b/app/sanity/fetchGlobalData.test.ts
@@ -49,7 +49,10 @@ describe("fetchGlobalSanityData", () => {
     genderLabel: "Kjønn",
     citizenshipLabel: "Statsborgerskap",
     historyButton: "Historikk",
-    createReportCardButton: "Opprett meldekort",
+    createReportCardButton: {
+      label: "Opprett meldekort",
+      description: "Det kan ikke opprettes meldekort manuelt for brukere i Arena",
+    },
   };
 
   const mockBekreftModalData: IMeldekortBekreftModal = {


### PR DESCRIPTION
## Beskrivelse
Knappen for å opprette meldekort er skjult med en forklaring for de brukere som har meldekort i Arena og ikke i DP-sak. Sanity er også oppdatert.

<img width="497" height="127" alt="Screenshot 2026-08-21 at 15 13 41" src="https://github.com/user-attachments/assets/3da8de81-300e-44f7-a3dc-b7d8045e9915" />
<img width="642" height="127" alt="Screenshot 2026-08-21 at 15 13 52" src="https://github.com/user-attachments/assets/e936f22d-16fd-4670-a133-ebf8202343d3" />
