### PR TITLE
RAMP-195 oppdater layout og legg ved error tekst 

### DIFF
--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -140,7 +140,7 @@ describe("OpprettMeldekortModal", () => {
 
     await user.click(screen.getByRole("button", { name: "Opprett" }));
 
-    expect(await screen.findByText("Velg fra- og til-dato.")).toBeInTheDocument();
+    expect(await screen.findAllByText("Du må velge dato")).toHaveLength(2);
     expect(onBekreftMock).not.toHaveBeenCalled();
     expect(onCloseMock).not.toHaveBeenCalled();
   });

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -6,7 +6,6 @@ import {
   InfoCard,
   Modal,
   useRangeDatepicker,
-  VStack,
 } from "@navikt/ds-react";
 import { format } from "date-fns";
 import { useEffect, useState } from "react";
@@ -49,6 +48,7 @@ export function OpprettMeldekortModal({
 
   const tekster = rootData?.sanityData?.opprettMeldekortModal;
   const [actionError, setActionError] = useState<string | undefined>();
+  const [visDatoFeil, setVisDatoFeil] = useState(false);
   const [hasPendingSubmission, setHasPendingSubmission] = useState(false);
   const fetcher = useFetcher<IOpprettMeldekortResponse>();
 
@@ -60,6 +60,7 @@ export function OpprettMeldekortModal({
 
   function resetFormState() {
     setActionError(undefined);
+    setVisDatoFeil(false);
     setHasPendingSubmission(false);
     reset();
   }
@@ -83,9 +84,12 @@ export function OpprettMeldekortModal({
 
   function handleBekreft() {
     if (!selectedRange?.from || !selectedRange.to) {
-      setActionError("Velg fra- og til-dato.");
+      setVisDatoFeil(true);
+      setActionError(undefined);
       return;
     }
+
+    setVisDatoFeil(false);
 
     if (!personId) {
       setActionError("Mangler personId.");
@@ -133,7 +137,7 @@ export function OpprettMeldekortModal({
       <Modal.Body>
         <div className={styles.content}>
           <DatePicker {...datepickerProps}>
-            <VStack gap="space-16">
+            <div className={styles.datepickers}>
               <DatePicker.Input
                 size="small"
                 {...fromInputProps}
@@ -142,6 +146,7 @@ export function OpprettMeldekortModal({
                   tekster?.fraDato?.helpText,
                   "opprettMeldekortModal.fraDato.helpText",
                 )}
+                error={visDatoFeil && !selectedRange?.from ? "Du må velge dato" : undefined}
               />
               <DatePicker.Input
                 size="small"
@@ -151,8 +156,9 @@ export function OpprettMeldekortModal({
                   tekster?.tilDato?.helpText,
                   "opprettMeldekortModal.tilDato.helpText",
                 )}
+                error={visDatoFeil && !selectedRange?.to ? "Du må velge dato" : undefined}
               />
-            </VStack>
+            </div>
           </DatePicker>
           {actionError && <Alert variant="error">{actionError}</Alert>}
           <BodyShort>{forklaringstekst}</BodyShort>

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.module.css
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.module.css
@@ -2,4 +2,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--ax-space-24);
+  padding: var(--ax-space-24);
+}
+
+.datepickers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-24);
+  @media (min-width: 768px) {
+    flex-direction: row;
+    width: 80%;
+  }
 }


### PR DESCRIPTION
Oppdaterer layout for inputfeltene så de ligger riktig, med riktig padding og skalering fra liten til stor skjerm. Legger også ved riktige "mangler dato" feilmelding. 
<img width="736" height="405" alt="Screenshot 2026-08-24 at 11 29 50" src="https://github.com/user-attachments/assets/8c1dc8a5-c82b-4ec3-9e32-c3856dec9e45" />

<img width="499" height="444" alt="Screenshot 2026-08-24 at 11 30 03" src="https://github.com/user-attachments/assets/3ced534a-e220-45ca-999b-e308233a69dd" />

<img width="736" height="405" alt="Screenshot 2026-08-24 at 11 29 41" src="https://github.com/user-attachments/assets/a74f7abe-8fb2-459d-9e96-4edf1ba0d710" />
