### PR TITLE
oppdater fremvisning og mock innhold RAMP-197 ramp-klar-til-oppskalering

### DIFF
--- a/app/mocks/data/mock-persons.ts
+++ b/app/mocks/data/mock-persons.ts
@@ -1,7 +1,8 @@
 import { ANSVARLIG_SYSTEM, KJONN } from "~/utils/constants";
+import { ScenarioType } from "~/utils/scenario.types";
 import type { IPerson } from "~/utils/types";
 
-const personData: Array<IPerson & { id: string }> = [
+const personData: Array<IPerson & { id: string; scenario?: ScenarioType }> = [
   {
     ident: "02028212345",
     id: "2277730",
@@ -13,9 +14,21 @@ const personData: Array<IPerson & { id: string }> = [
     kjonn: KJONN.MANN,
     fodselsdato: "1982-02-02",
   },
+  {
+    ident: "03038512346",
+    id: "2277731",
+    fornavn: "Kari",
+    mellomnavn: "",
+    etternavn: "Utsatt",
+    statsborgerskap: "Norsk",
+    ansvarligSystem: ANSVARLIG_SYSTEM.DP,
+    kjonn: KJONN.KVINNE,
+    fodselsdato: "1985-03-03",
+    scenario: ScenarioType.STOPPET_FOR_3_MANEDER,
+  },
 ];
 
-export const mockPersons: Array<IPerson & { id: string }> = personData;
+export const mockPersons: Array<IPerson & { id: string; scenario?: ScenarioType }> = personData;
 
 export const getFullDemoPerson = () => {
   return mockPersons[0];

--- a/app/mocks/data/mock-rapporteringsperioder.ts
+++ b/app/mocks/data/mock-rapporteringsperioder.ts
@@ -436,6 +436,54 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     },
   ],
 
+  // Brukers meldekort stanset for ca. 3 måneder siden. Ingen perioder etter
+  // det——behøves for å teste "opprett meldekort" for perioder som mangler.
+  // Hardkodede ID-er for demo-miljø slik at URL-er kan deles og overlever HMR-reseeding.
+  [ScenarioType.STOPPET_FOR_3_MANEDER]: [
+    {
+      periode: {
+        id: "019a6ded-0100-7000-a000-000000000001",
+        status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
+        registrertArbeidssoker: true,
+        kanSendes: false,
+        kanEndres: true,
+      },
+      ukerFraIDag: 19,
+      aktiviteter: lagArbeidUker("7.5"),
+    },
+    {
+      periode: {
+        id: "019a6ded-0100-7000-a000-000000000002",
+        status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
+        registrertArbeidssoker: true,
+        kanSendes: false,
+        kanEndres: true,
+      },
+      ukerFraIDag: 17,
+      aktiviteter: lagAlternerendeArbeidsUker("4"),
+    },
+    {
+      periode: {
+        id: "019a6ded-0100-7000-a000-000000000003",
+        status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
+        registrertArbeidssoker: true,
+        kanSendes: false,
+        kanEndres: true,
+      },
+      ukerFraIDag: 15,
+    },
+    {
+      periode: {
+        id: "019a6ded-0100-7000-a000-000000000004",
+        status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
+        registrertArbeidssoker: true,
+        kanSendes: false,
+        kanEndres: true,
+      },
+      ukerFraIDag: 13,
+    },
+  ],
+
   [ScenarioType.FULL_DEMO]: [
     // Arena meldekort innsendt med aktiviteter
     // Hardkodet ID for demo-miljø slik at URL-er kan deles

--- a/app/mocks/data/mock-rapporteringsperioder.ts
+++ b/app/mocks/data/mock-rapporteringsperioder.ts
@@ -438,7 +438,9 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
 
   // Brukers meldekort stanset for ca. 3 måneder siden. Ingen perioder etter
   // det——behøves for å teste "opprett meldekort" for perioder som mangler.
-  // Hardkodede ID-er for demo-miljø slik at URL-er kan deles og overlever HMR-reseeding.
+  // Hardkodede ID-er for demo-miljø slik at URL-er kan deles: i dev-modus laster Vite på nytt
+  // og genererer nye data ved hvert filsave, så uten faste ID-er ville periode-URL-er sluttet
+  // å fungere hver gang man lagrer en fil mens man ser på denne brukeren.
   [ScenarioType.STOPPET_FOR_3_MANEDER]: [
     {
       periode: {
@@ -518,6 +520,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // Arena meldekort innsendt (etterregistrert)
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000002",
         opprettetAv: OPPRETTET_AV.Arena,
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
@@ -545,6 +548,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 5. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000003",
         opprettetAv: OPPRETTET_AV.Arena,
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
@@ -573,6 +577,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 6. Ferdig beregnet, Syk torsdag uke 22, Sendt inn en dag etter fristen
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000004",
         opprettetAv: OPPRETTET_AV.Arena,
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
@@ -645,6 +650,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 9. Ferdig beregnet, Arbeid 4 timer hver onsdag
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000005",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -671,6 +677,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 10. Ferdig beregnet, Arbeid 4 timer hver onsdag
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000006",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -697,6 +704,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 11. Ferdig beregnet, ingen aktiviteter
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000007",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -727,6 +735,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 12. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000008",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -753,6 +762,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 13. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000009",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -779,6 +789,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 14. Ferdig beregnet,  ingen aktiviteter
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000000a",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -789,6 +800,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 15. Ferdig beregnet,  ingen aktiviteter
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000000b",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -844,6 +856,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 18. Ferdig beregnet, ingen aktiviteter
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000000c",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -854,6 +867,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 19. Ferdig beregnet,  Arbeid 4 timer hver onsdag
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000000d",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -890,6 +904,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 21. Ferdig beregnet,  Arbeid 4 timer hver onsdag
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000000f",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -916,6 +931,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 22. Ferdig beregnet,  ingen aktiviteter
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000010",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -927,6 +943,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 23. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000011",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -953,6 +970,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 24. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000012",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -979,6 +997,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 25. Ferdig beregnet, Utdanning onsdag, Jobb tirsdag/torsdag 2h, Syk fredag uke 2
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000013",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1005,6 +1024,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 26. Ferdig beregnet, Arbeid 4 timer hver onsdag
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000014",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1031,6 +1051,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 27.
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000015",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1041,6 +1062,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 28.
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000016",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1051,6 +1073,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 29.
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000017",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1061,6 +1084,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 30.
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000018",
         status: RAPPORTERINGSPERIODE_STATUS.Innsendt,
         registrertArbeidssoker: true,
         kanSendes: false,
@@ -1071,6 +1095,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 32. Nyeste innsendte meldekort
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-000000000019",
         status: RAPPORTERINGSPERIODE_STATUS.TilUtfylling,
         kanSendes: true,
         kanEndres: false,
@@ -1081,6 +1106,7 @@ const SCENARIO_CONFIGS: Record<ScenarioType, PeriodeConfig[]> = {
     // 33. Opprettet meldekort
     {
       periode: {
+        id: "019a6dee-0000-7000-a000-00000000001a",
         status: RAPPORTERINGSPERIODE_STATUS.TilUtfylling,
         kanSendes: false,
         kanEndres: false, // Kan ikke endres fordi den ikke er innsendt ennå

--- a/app/mocks/session.ts
+++ b/app/mocks/session.ts
@@ -35,11 +35,12 @@ class SessionRecord {
 
       // Lag personer med perioder
       for (const personData of mockPersons) {
-        const createdPerson = (await db.personer.create(personData)) as IPerson;
+        const { scenario, ...person } = personData;
+        const createdPerson = (await db.personer.create(person)) as IPerson;
 
-        // Generer perioder basert på FULL_DEMO scenario
+        // Generer perioder basert på personens scenario (default FULL_DEMO)
         const periods = hentRapporteringsperioderForScenario(
-          ScenarioType.FULL_DEMO,
+          scenario ?? ScenarioType.FULL_DEMO,
           createdPerson,
           createdSaksbehandler,
         );

--- a/app/mocks/session.ts
+++ b/app/mocks/session.ts
@@ -12,7 +12,7 @@ import { mockSaksbehandler } from "./data/mock-saksbehandler";
 
 export type Database = ReturnType<SessionRecord["createDatabase"]>;
 
-type SessionMap = Map<string, Database>;
+type SessionMap = Map<string, Promise<Database>>;
 
 class SessionRecord {
   private sessions: SessionMap;
@@ -21,57 +21,64 @@ class SessionRecord {
     this.sessions = new Map();
   }
 
-  public async getDatabase(
-    sessionId: string,
-  ): Promise<ReturnType<SessionRecord["createDatabase"]>> {
-    if (!this.sessions.has(sessionId)) {
-      const db = this.createDatabase();
+  public async getDatabase(sessionId: string): Promise<Database> {
+    let pendingDatabase = this.sessions.get(sessionId);
 
-      this.sessions.set(sessionId, db);
-
-      const createdSaksbehandler = (await db.saksbehandlere.create(
-        mockSaksbehandler,
-      )) as ISaksbehandler;
-
-      // Lag personer med perioder
-      for (const personData of mockPersons) {
-        const { scenario, ...person } = personData;
-        const createdPerson = (await db.personer.create(person)) as IPerson;
-
-        // Generer perioder basert på personens scenario (default FULL_DEMO)
-        const periods = hentRapporteringsperioderForScenario(
-          scenario ?? ScenarioType.FULL_DEMO,
-          createdPerson,
-          createdSaksbehandler,
-        );
-
-        await Promise.all(
-          periods.map((rapporteringsperiode) => {
-            db.rapporteringsperioder.create(rapporteringsperiode);
-          }),
-        );
-
-        const arbeidssokerperioder = hentArbeidssokerperioder(periods, createdPerson, true);
-
-        await Promise.all(
-          arbeidssokerperioder.map((arbeidssokerperiode) =>
-            db.arbeidssokerperioder.create(arbeidssokerperiode),
-          ),
-        );
-
-        const behandlingsresultat = hentBehandlingsresultat(
-          createdPerson,
-          periods,
-          arbeidssokerperioder,
-        );
-
-        await Promise.all(
-          behandlingsresultat.map((behandling) => db.behandlingsresultat.create(behandling)),
-        );
-      }
+    if (!pendingDatabase) {
+      pendingDatabase = this.seedDatabase();
+      // Registrer promisen før seeding er ferdig, så samtidige loadere (root, person, perioder)
+      // venter på samme seeding i stedet for å lese en halvferdig database.
+      this.sessions.set(sessionId, pendingDatabase);
     }
 
-    return this.sessions.get(sessionId)!;
+    return pendingDatabase;
+  }
+
+  private async seedDatabase(): Promise<Database> {
+    const db = this.createDatabase();
+
+    const createdSaksbehandler = (await db.saksbehandlere.create(
+      mockSaksbehandler,
+    )) as ISaksbehandler;
+
+    // Lag personer med perioder
+    for (const personData of mockPersons) {
+      const { scenario, ...person } = personData;
+      const createdPerson = (await db.personer.create(person)) as IPerson;
+
+      // Generer perioder basert på personens scenario (default FULL_DEMO)
+      const periods = hentRapporteringsperioderForScenario(
+        scenario ?? ScenarioType.FULL_DEMO,
+        createdPerson,
+        createdSaksbehandler,
+      );
+
+      await Promise.all(
+        periods.map((rapporteringsperiode) => {
+          db.rapporteringsperioder.create(rapporteringsperiode);
+        }),
+      );
+
+      const arbeidssokerperioder = hentArbeidssokerperioder(periods, createdPerson, true);
+
+      await Promise.all(
+        arbeidssokerperioder.map((arbeidssokerperiode) =>
+          db.arbeidssokerperioder.create(arbeidssokerperiode),
+        ),
+      );
+
+      const behandlingsresultat = hentBehandlingsresultat(
+        createdPerson,
+        periods,
+        arbeidssokerperioder,
+      );
+
+      await Promise.all(
+        behandlingsresultat.map((behandling) => db.behandlingsresultat.create(behandling)),
+      );
+    }
+
+    return db;
   }
 
   private createDatabase() {

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -32,8 +32,7 @@ mockUseRouteLoaderData.mockReturnValue({
       avbrytKnapp: "Avbryt",
       infoBoks: {
         tittel: "Info om meldekortsyklus",
-        tekst:
-          "Nye meldekort opprettes i samme syklus som den bruker allerede har. Meldekort opprettes hver 14. dag.",
+        tekst: "Dette vil opprette {{antall}} meldekort.",
       },
       feilmelding: {
         tittel: "Kunne ikke opprette meldekort",
@@ -110,11 +109,7 @@ describe("OpprettMeldekortModal", () => {
     renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
 
     expect(screen.getByText("Info om meldekortsyklus")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Nye meldekort opprettes i samme syklus som den bruker allerede har. Meldekort opprettes hver 14. dag.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Dette vil opprette 0 meldekort.")).toBeInTheDocument();
   });
 
   it("skal vise opprett-knapp", () => {
@@ -260,6 +255,56 @@ describe("OpprettMeldekortModal", () => {
 
       expect(fromInput).toBeInTheDocument();
       expect(toInput).toBeInTheDocument();
+    });
+  });
+
+  describe("Simulering av opprettelse", () => {
+    function renderMedSimulering(ui: React.ReactElement) {
+      const Stub = createRoutesStub([
+        {
+          path: "/",
+          Component: () => <SaksbehandlerProvider>{ui}</SaksbehandlerProvider>,
+        },
+        {
+          path: "/api/opprett-meldekort",
+          action: async ({ request }) => {
+            const formData = await request.formData();
+
+            if (formData.get("simulering") === "true") {
+              return {
+                success: true,
+                perioder: [{ fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" }],
+              };
+            }
+
+            return { success: true };
+          },
+        },
+      ]);
+
+      return render(<Stub initialEntries={["/"]} />);
+    }
+
+    it("skal simulere opprettelsen når begge datoer er valgt og vise forh\u00e5ndsvisning", async () => {
+      const user = userEvent.setup();
+      renderMedSimulering(<OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />);
+
+      await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
+      await user.type(screen.getByLabelText("Til dato"), "19.01.2025");
+
+      expect(await screen.findByText("Dette vil opprette 1 meldekort.")).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: "Ukenummer" })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: "Periode" })).toBeInTheDocument();
+      expect(screen.getByText(/06.01.2025.*19.01.2025/)).toBeInTheDocument();
+    });
+
+    it("skal ikke vise forhåndsvisning når kun én dato er valgt", async () => {
+      const user = userEvent.setup();
+      renderMedSimulering(<OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />);
+
+      await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
+
+      expect(screen.getByText("Dette vil opprette 0 meldekort.")).toBeInTheDocument();
     });
   });
 });

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -5,6 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { SaksbehandlerProvider } from "~/context/saksbehandler-context";
 
+function harTekst(forventetTekst: string) {
+  return (_content: string, element: Element | null) => element?.textContent === forventetTekst;
+}
+
 const mockUseRouteLoaderData = vi.hoisted(() => vi.fn());
 
 vi.mock("react-router", async (importOriginal) => ({
@@ -105,11 +109,10 @@ describe("OpprettMeldekortModal", () => {
     expect(screen.getByLabelText("Til dato")).toBeInTheDocument();
   });
 
-  it("skal vise info-boks med informasjon om meldekortsyklus", () => {
+  it("skal ikke vise info-boks når ingen perioder er simulert", () => {
     renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} />);
 
-    expect(screen.getByText("Info om meldekortsyklus")).toBeInTheDocument();
-    expect(screen.getByText("Dette vil opprette 0 meldekort.")).toBeInTheDocument();
+    expect(screen.queryByText("Info om meldekortsyklus")).not.toBeInTheDocument();
   });
 
   it("skal vise opprett-knapp", () => {
@@ -285,14 +288,16 @@ describe("OpprettMeldekortModal", () => {
       return render(<Stub initialEntries={["/"]} />);
     }
 
-    it("skal simulere opprettelsen når begge datoer er valgt og vise forh\u00e5ndsvisning", async () => {
+    it("skal simulere opprettelsen når begge datoer er valgt og vise forhåndsvisning", async () => {
       const user = userEvent.setup();
       renderMedSimulering(<OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />);
 
       await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
       await user.type(screen.getByLabelText("Til dato"), "19.01.2025");
 
-      expect(await screen.findByText("Dette vil opprette 1 meldekort.")).toBeInTheDocument();
+      expect(
+        await screen.findByText(harTekst("Dette vil opprette 1 meldekort.")),
+      ).toBeInTheDocument();
       expect(screen.getByRole("columnheader", { name: "Ukenummer" })).toBeInTheDocument();
       expect(screen.getByRole("columnheader", { name: "Periode" })).toBeInTheDocument();
       expect(screen.getByText(/06.01.2025.*19.01.2025/)).toBeInTheDocument();
@@ -304,7 +309,85 @@ describe("OpprettMeldekortModal", () => {
 
       await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
 
-      expect(screen.getByText("Dette vil opprette 0 meldekort.")).toBeInTheDocument();
+      expect(screen.queryByText("Info om meldekortsyklus")).not.toBeInTheDocument();
+    });
+
+    it("skal vise lastestatus mens simuleringen pågår", async () => {
+      const user = userEvent.setup();
+      let løsSimulering: (() => void) | undefined;
+      const simuleringPromise = new Promise<void>((resolve) => {
+        løsSimulering = resolve;
+      });
+
+      const Stub = createRoutesStub([
+        {
+          path: "/",
+          Component: () => (
+            <SaksbehandlerProvider>
+              <OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />
+            </SaksbehandlerProvider>
+          ),
+        },
+        {
+          path: "/api/opprett-meldekort",
+          action: async () => {
+            await simuleringPromise;
+            return {
+              success: true,
+              perioder: [{ fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" }],
+            };
+          },
+        },
+      ]);
+
+      render(<Stub initialEntries={["/"]} />);
+
+      await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
+      await user.type(screen.getByLabelText("Til dato"), "19.01.2025");
+
+      expect(
+        await screen.findByTestId("opprett-meldekort-simulering-skeleton"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(harTekst("Dette vil opprette 1 meldekort.")),
+      ).not.toBeInTheDocument();
+
+      løsSimulering?.();
+
+      expect(
+        await screen.findByText(harTekst("Dette vil opprette 1 meldekort.")),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("opprett-meldekort-simulering-skeleton")).not.toBeInTheDocument();
+    });
+
+    it("skal ikke vise info-boks når simuleringen feiler", async () => {
+      const user = userEvent.setup();
+      const Stub = createRoutesStub([
+        {
+          path: "/",
+          Component: () => (
+            <SaksbehandlerProvider>
+              <OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />
+            </SaksbehandlerProvider>
+          ),
+        },
+        {
+          path: "/api/opprett-meldekort",
+          action: async () => ({ error: "Kunne ikke beregne", status: 500 }),
+        },
+      ]);
+
+      render(<Stub initialEntries={["/"]} />);
+
+      await user.type(screen.getByLabelText("Fra dato"), "06.01.2025");
+      await user.type(screen.getByLabelText("Til dato"), "19.01.2025");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("opprett-meldekort-simulering-skeleton"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("Info om meldekortsyklus")).not.toBeInTheDocument();
     });
   });
 });

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -3,24 +3,27 @@ import {
   BodyShort,
   Button,
   DatePicker,
-  InfoCard,
   Modal,
+  Skeleton,
   useRangeDatepicker,
 } from "@navikt/ds-react";
 import { format } from "date-fns";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFetcher, useRouteLoaderData } from "react-router";
 
 import { sanityTekst } from "~/sanity/utils";
 import { getTodayIsoDate } from "~/utils/dato.utils";
-import { addDemoParamsToURL } from "~/utils/demo-params.utils";
 
 import { OpprettMeldekortInfoBoks } from "./components/OpprettMeldekortInfoBoks";
 import {
   buildOpprettMeldekortFormData,
+  byggOpprettMeldekortActionUrl,
+  erSammePeriode,
   type IOpprettMeldekortPayload,
   type IOpprettMeldekortResponse,
+  type IPeriodeIntervall,
   toOpprettMeldekortErrorMessage,
+  utledGyldigPeriode,
 } from "./opprettMeldekortModal.helpers";
 import styles from "./opprettMeldekortModal.module.css";
 
@@ -53,6 +56,9 @@ export function OpprettMeldekortModal({
   const fetcher = useFetcher<IOpprettMeldekortResponse>();
   const simuleringFetcher = useFetcher<IOpprettMeldekortResponse>();
 
+  const [simulertRange, setSimulertRange] = useState<IPeriodeIntervall | null>(null);
+  const ventendeRangeRef = useRef<IPeriodeIntervall | null>(null);
+
   const { datepickerProps, fromInputProps, toInputProps, reset, selectedRange } =
     useRangeDatepicker({
       fromDate: undefined,
@@ -66,11 +72,7 @@ export function OpprettMeldekortModal({
     reset();
   }
 
-  function byggOpprettMeldekortActionUrl(): string {
-    const actionUrl = new URL("/api/opprett-meldekort", window.location.origin);
-    addDemoParamsToURL(actionUrl);
-    return actionUrl.pathname + actionUrl.search;
-  }
+  const valgtPeriode = utledGyldigPeriode(selectedRange);
 
   useEffect(() => {
     if (!hasPendingSubmission || fetcher.state !== "idle" || !fetcher.data) {
@@ -89,26 +91,33 @@ export function OpprettMeldekortModal({
     setActionError(toOpprettMeldekortErrorMessage(fetcher.data));
   }, [hasPendingSubmission, fetcher.state, fetcher.data, onBekreft, onClose]);
 
-  // Simuler opprettelsen så snart begge datoer er valgt, for å vise hvilke perioder som opprettes
-  useEffect(() => {
-    if (!personId || !selectedRange?.from || !selectedRange.to) {
+  function startSimuleringAvMeldekortOpprettelse() {
+    if (!personId || !valgtPeriode) {
+      ventendeRangeRef.current = null;
       return;
     }
 
-    const fraOgMed = format(selectedRange.from, "yyyy-MM-dd");
-    const tilOgMed = format(selectedRange.to, "yyyy-MM-dd");
-    const today = getTodayIsoDate();
-    const erGyldigPeriode = fraOgMed <= tilOgMed && fraOgMed <= today && tilOgMed <= today;
-
-    if (!erGyldigPeriode) {
-      return;
-    }
+    ventendeRangeRef.current = valgtPeriode;
 
     simuleringFetcher.submit(
-      buildOpprettMeldekortFormData({ personId, fraOgMed, tilOgMed, simulering: true }),
+      buildOpprettMeldekortFormData({ personId, ...valgtPeriode, simulering: true }),
       { method: "post", action: byggOpprettMeldekortActionUrl() },
     );
-  }, [personId, selectedRange?.from, selectedRange?.to]);
+  }
+
+  useEffect(startSimuleringAvMeldekortOpprettelse, [
+    personId,
+    valgtPeriode?.fraOgMed,
+    valgtPeriode?.tilOgMed,
+  ]);
+
+  useEffect(() => {
+    if (simuleringFetcher.state !== "idle" || !simuleringFetcher.data) {
+      return;
+    }
+
+    setSimulertRange(ventendeRangeRef.current);
+  }, [simuleringFetcher.state, simuleringFetcher.data]);
 
   function handleBekreft() {
     if (!selectedRange?.from || !selectedRange.to) {
@@ -155,15 +164,18 @@ export function OpprettMeldekortModal({
     "opprettMeldekortModal.forklaringstekst",
   );
 
+  const lasterSimulering =
+    Boolean(personId) && valgtPeriode !== null && !erSammePeriode(simulertRange, valgtPeriode);
+
   const simulertePerioder =
-    selectedRange?.from && selectedRange.to && simuleringFetcher.data?.success
+    erSammePeriode(simulertRange, valgtPeriode) && simuleringFetcher.data?.success
       ? (simuleringFetcher.data.perioder ?? [])
       : [];
 
   const infoBoksTekst = sanityTekst(
     tekster?.infoBoks?.tekst,
     "opprettMeldekortModal.infoBoks.tekst",
-  ).replace("{{antall}}", String(simulertePerioder.length));
+  );
 
   return (
     <Modal open={open} onClose={handleClose} aria-label={tittelMedNavn} size="medium">
@@ -198,24 +210,24 @@ export function OpprettMeldekortModal({
           </DatePicker>
           {actionError && <Alert variant="error">{actionError}</Alert>}
           <BodyShort>{forklaringstekst}</BodyShort>
-          <OpprettMeldekortInfoBoks
-            tittel={sanityTekst(tekster?.infoBoks?.tittel, "opprettMeldekortModal.infoBoks.tittel")}
-            tekst={infoBoksTekst}
-            perioder={simulertePerioder}
-          />
-          <InfoCard data-color="danger" size="small">
-            <InfoCard.Header>
-              <InfoCard.Title>
-                {sanityTekst(
-                  tekster?.feilmelding?.tittel,
-                  "opprettMeldekortModal.feilmelding.tittel",
-                )}
-              </InfoCard.Title>
-            </InfoCard.Header>
-            <InfoCard.Content>
-              {sanityTekst(tekster?.feilmelding?.tekst, "opprettMeldekortModal.feilmelding.tekst")}
-            </InfoCard.Content>
-          </InfoCard>
+          {lasterSimulering && (
+            <Skeleton
+              variant="rounded"
+              width="100%"
+              height="5rem"
+              data-testid="opprett-meldekort-simulering-skeleton"
+            />
+          )}
+          {simulertePerioder.length > 0 && (
+            <OpprettMeldekortInfoBoks
+              tittel={sanityTekst(
+                tekster?.infoBoks?.tittel,
+                "opprettMeldekortModal.infoBoks.tittel",
+              )}
+              tekst={infoBoksTekst}
+              perioder={simulertePerioder}
+            />
+          )}
         </div>
       </Modal.Body>
       <Modal.Footer>

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -15,6 +15,7 @@ import { sanityTekst } from "~/sanity/utils";
 import { getTodayIsoDate } from "~/utils/dato.utils";
 import { addDemoParamsToURL } from "~/utils/demo-params.utils";
 
+import { OpprettMeldekortInfoBoks } from "./components/OpprettMeldekortInfoBoks";
 import {
   buildOpprettMeldekortFormData,
   type IOpprettMeldekortPayload,
@@ -38,7 +39,6 @@ export function OpprettMeldekortModal({
   brukerNavn,
   personId,
 }: OpprettMeldekortModalProps) {
-  // Hent tekster fra Sanity med fallback
   let rootData;
   try {
     rootData = useRouteLoaderData("root");
@@ -51,6 +51,7 @@ export function OpprettMeldekortModal({
   const [visDatoFeil, setVisDatoFeil] = useState(false);
   const [hasPendingSubmission, setHasPendingSubmission] = useState(false);
   const fetcher = useFetcher<IOpprettMeldekortResponse>();
+  const simuleringFetcher = useFetcher<IOpprettMeldekortResponse>();
 
   const { datepickerProps, fromInputProps, toInputProps, reset, selectedRange } =
     useRangeDatepicker({
@@ -63,6 +64,12 @@ export function OpprettMeldekortModal({
     setVisDatoFeil(false);
     setHasPendingSubmission(false);
     reset();
+  }
+
+  function byggOpprettMeldekortActionUrl(): string {
+    const actionUrl = new URL("/api/opprett-meldekort", window.location.origin);
+    addDemoParamsToURL(actionUrl);
+    return actionUrl.pathname + actionUrl.search;
   }
 
   useEffect(() => {
@@ -81,6 +88,27 @@ export function OpprettMeldekortModal({
 
     setActionError(toOpprettMeldekortErrorMessage(fetcher.data));
   }, [hasPendingSubmission, fetcher.state, fetcher.data, onBekreft, onClose]);
+
+  // Simuler opprettelsen så snart begge datoer er valgt, for å vise hvilke perioder som opprettes
+  useEffect(() => {
+    if (!personId || !selectedRange?.from || !selectedRange.to) {
+      return;
+    }
+
+    const fraOgMed = format(selectedRange.from, "yyyy-MM-dd");
+    const tilOgMed = format(selectedRange.to, "yyyy-MM-dd");
+    const today = getTodayIsoDate();
+    const erGyldigPeriode = fraOgMed <= tilOgMed && fraOgMed <= today && tilOgMed <= today;
+
+    if (!erGyldigPeriode) {
+      return;
+    }
+
+    simuleringFetcher.submit(
+      buildOpprettMeldekortFormData({ personId, fraOgMed, tilOgMed, simulering: true }),
+      { method: "post", action: byggOpprettMeldekortActionUrl() },
+    );
+  }, [personId, selectedRange?.from, selectedRange?.to]);
 
   function handleBekreft() {
     if (!selectedRange?.from || !selectedRange.to) {
@@ -106,15 +134,12 @@ export function OpprettMeldekortModal({
       return;
     }
 
-    const payload: IOpprettMeldekortPayload = { personId, fraOgMed, tilOgMed };
-
-    const actionUrl = new URL("/api/opprett-meldekort", window.location.origin);
-    addDemoParamsToURL(actionUrl);
+    const payload: IOpprettMeldekortPayload = { personId, fraOgMed, tilOgMed, simulering: false };
 
     setHasPendingSubmission(true);
     fetcher.submit(buildOpprettMeldekortFormData(payload), {
       method: "post",
-      action: actionUrl.pathname + actionUrl.search,
+      action: byggOpprettMeldekortActionUrl(),
     });
   }
 
@@ -129,6 +154,17 @@ export function OpprettMeldekortModal({
     tekster?.forklaringstekst,
     "opprettMeldekortModal.forklaringstekst",
   );
+
+  const simulertePerioder =
+    selectedRange?.from && selectedRange.to && simuleringFetcher.data?.success
+      ? (simuleringFetcher.data.perioder ?? [])
+      : [];
+
+  const infoBoksTekst = sanityTekst(
+    tekster?.infoBoks?.tekst,
+    "opprettMeldekortModal.infoBoks.tekst",
+  ).replace("{{antall}}", String(simulertePerioder.length));
+
   return (
     <Modal open={open} onClose={handleClose} aria-label={tittelMedNavn} size="medium">
       <Modal.Header>
@@ -162,18 +198,11 @@ export function OpprettMeldekortModal({
           </DatePicker>
           {actionError && <Alert variant="error">{actionError}</Alert>}
           <BodyShort>{forklaringstekst}</BodyShort>
-          <InfoCard data-color="info" size="small">
-            <InfoCard.Header>
-              <InfoCard.Title>
-                {sanityTekst(tekster?.infoBoks?.tittel, "opprettMeldekortModal.infoBoks.tittel")}
-              </InfoCard.Title>
-            </InfoCard.Header>
-            <InfoCard.Content>
-              <BodyShort>
-                {sanityTekst(tekster?.infoBoks?.tekst, "opprettMeldekortModal.infoBoks.tekst")}
-              </BodyShort>
-            </InfoCard.Content>
-          </InfoCard>
+          <OpprettMeldekortInfoBoks
+            tittel={sanityTekst(tekster?.infoBoks?.tittel, "opprettMeldekortModal.infoBoks.tittel")}
+            tekst={infoBoksTekst}
+            perioder={simulertePerioder}
+          />
           <InfoCard data-color="danger" size="small">
             <InfoCard.Header>
               <InfoCard.Title>

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -165,7 +165,7 @@ export function OpprettMeldekortModal({
   );
 
   const lasterSimulering =
-    Boolean(personId) && valgtPeriode !== null && !erSammePeriode(simulertRange, valgtPeriode);
+    Boolean(personId) && valgtPeriode !== null && simuleringFetcher.state !== "idle";
 
   const simulertePerioder =
     erSammePeriode(simulertRange, valgtPeriode) && simuleringFetcher.data?.success

--- a/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
+++ b/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
@@ -15,40 +15,44 @@ export function OpprettMeldekortInfoBoks({
   tekst,
   perioder,
 }: OpprettMeldekortInfoBoksProps) {
+  const [tekstFor, tekstEtter] = tekst.split("{{antall}}");
+
   return (
     <InfoCard data-color="info" size="small">
       <InfoCard.Header>
         <InfoCard.Title>{tittel}</InfoCard.Title>
       </InfoCard.Header>
       <InfoCard.Content className={styles.informationContent}>
-        <BodyShort>{tekst}</BodyShort>
-        {perioder.length > 0 && (
-          <div className={styles.periodeTabellWrapper}>
-            <table className={styles.periodeTabell}>
-              <colgroup>
-                <col className={styles.ukenummerKolonne} />
-                <col className={styles.periodeKolonne} />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th scope="col">Ukenummer</th>
-                  <th scope="col">Periode</th>
+        <BodyShort>
+          {tekstFor}
+          <strong>{perioder.length}</strong>
+          {tekstEtter}
+        </BodyShort>
+        <div className={styles.periodeTabellWrapper}>
+          <table className={styles.periodeTabell}>
+            <colgroup>
+              <col className={styles.ukenummerKolonne} />
+              <col className={styles.periodeKolonne} />
+            </colgroup>
+            <thead>
+              <tr>
+                <th scope="col">Ukenummer</th>
+                <th scope="col">Periode</th>
+              </tr>
+            </thead>
+            <tbody>
+              {perioder.map((periode) => (
+                <tr key={`${periode.fraOgMed}-${periode.tilOgMed}`}>
+                  <td>{formaterPeriodeTilUkenummer(periode.fraOgMed, periode.tilOgMed)}</td>
+                  <td>
+                    {formatterDato({ dato: periode.fraOgMed, format: DatoFormat.DagMndAar })} –{" "}
+                    {formatterDato({ dato: periode.tilOgMed, format: DatoFormat.DagMndAar })}
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {perioder.map((periode) => (
-                  <tr key={`${periode.fraOgMed}-${periode.tilOgMed}`}>
-                    <td>{formaterPeriodeTilUkenummer(periode.fraOgMed, periode.tilOgMed)}</td>
-                    <td>
-                      {formatterDato({ dato: periode.fraOgMed, format: DatoFormat.DagMndAar })} –{" "}
-                      {formatterDato({ dato: periode.tilOgMed, format: DatoFormat.DagMndAar })}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+              ))}
+            </tbody>
+          </table>
+        </div>
       </InfoCard.Content>
     </InfoCard>
   );

--- a/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
+++ b/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
@@ -1,0 +1,55 @@
+import { BodyShort, InfoCard } from "@navikt/ds-react";
+
+import { DatoFormat, formaterPeriodeTilUkenummer, formatterDato } from "~/utils/dato.utils";
+
+import styles from "./opprettMeldekortInfoBoks.module.css";
+
+interface OpprettMeldekortInfoBoksProps {
+  tittel: string;
+  tekst: string;
+  perioder: Array<{ fraOgMed: string; tilOgMed: string }>;
+}
+
+export function OpprettMeldekortInfoBoks({
+  tittel,
+  tekst,
+  perioder,
+}: OpprettMeldekortInfoBoksProps) {
+  return (
+    <InfoCard data-color="info" size="small">
+      <InfoCard.Header>
+        <InfoCard.Title>{tittel}</InfoCard.Title>
+      </InfoCard.Header>
+      <InfoCard.Content className={styles.informationContent}>
+        <BodyShort>{tekst}</BodyShort>
+        {perioder.length > 0 && (
+          <div className={styles.periodeTabellWrapper}>
+            <table className={styles.periodeTabell}>
+              <colgroup>
+                <col className={styles.ukenummerKolonne} />
+                <col className={styles.periodeKolonne} />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th scope="col">Ukenummer</th>
+                  <th scope="col">Periode</th>
+                </tr>
+              </thead>
+              <tbody>
+                {perioder.map((periode) => (
+                  <tr key={`${periode.fraOgMed}-${periode.tilOgMed}`}>
+                    <td>{formaterPeriodeTilUkenummer(periode.fraOgMed, periode.tilOgMed)}</td>
+                    <td>
+                      {formatterDato({ dato: periode.fraOgMed, format: DatoFormat.DagMndAar })} –{" "}
+                      {formatterDato({ dato: periode.tilOgMed, format: DatoFormat.DagMndAar })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </InfoCard.Content>
+    </InfoCard>
+  );
+}

--- a/app/modals/opprett-meldekort/components/opprettMeldekortInfoBoks.module.css
+++ b/app/modals/opprett-meldekort/components/opprettMeldekortInfoBoks.module.css
@@ -1,0 +1,35 @@
+.informationContent {
+  display: grid;
+  gap: var(--ax-space-16);
+}
+
+.periodeTabellWrapper {
+  padding: var(--ax-space-6) var(--ax-space-12);
+}
+
+.periodeTabell {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.periodeTabell th,
+.periodeTabell td {
+  padding: 0 var(--ax-space-8);
+  text-align: left;
+}
+
+.periodeTabell th {
+  font-weight: 600;
+}
+
+.periodeTabell tbody tr:nth-child(even) {
+  background: var(--ax-bg-info-soft);
+}
+
+.ukenummerKolonne {
+  width: 33%;
+}
+
+.periodeKolonne {
+  width: 67%;
+}

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.test.ts
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOpprettMeldekortFormData,
+  erSammePeriode,
+  toOpprettMeldekortErrorMessage,
+  utledGyldigPeriode,
+} from "./opprettMeldekortModal.helpers";
+
+describe("opprettMeldekortModal.helpers", () => {
+  it("bygger formdata med simulering", () => {
+    const formData = buildOpprettMeldekortFormData({
+      personId: "123",
+      fraOgMed: "2025-01-06",
+      tilOgMed: "2025-01-19",
+      simulering: true,
+    });
+
+    expect(Object.fromEntries(formData)).toEqual({
+      personId: "123",
+      fraOgMed: "2025-01-06",
+      tilOgMed: "2025-01-19",
+      simulering: "true",
+    });
+  });
+
+  it("returnerer gyldig periode for et gyldig datointervall", () => {
+    expect(
+      utledGyldigPeriode({
+        from: new Date("2025-01-06"),
+        to: new Date("2025-01-19"),
+      }),
+    ).toEqual({ fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" });
+  });
+
+  it("avviser manglende, omvendt og fremtidig datointervall", () => {
+    expect(utledGyldigPeriode(undefined)).toBeNull();
+    expect(
+      utledGyldigPeriode({ from: new Date("2025-01-19"), to: new Date("2025-01-06") }),
+    ).toBeNull();
+    expect(
+      utledGyldigPeriode({ from: new Date("2999-01-06"), to: new Date("2999-01-19") }),
+    ).toBeNull();
+  });
+
+  it("sammenligner periodeintervaller", () => {
+    const periode = { fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" };
+
+    expect(erSammePeriode(periode, { ...periode })).toBe(true);
+    expect(erSammePeriode(periode, null)).toBe(false);
+    expect(erSammePeriode(periode, { fraOgMed: "2025-01-06", tilOgMed: "2025-01-20" })).toBe(false);
+  });
+
+  it("lager feilmelding med og uten detalj", () => {
+    expect(toOpprettMeldekortErrorMessage({ error: "Feil", detail: "Detalj" })).toBe(
+      "Feil: Detalj",
+    );
+    expect(toOpprettMeldekortErrorMessage({})).toBe("Kunne ikke opprette meldekort.");
+  });
+});

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
@@ -1,3 +1,8 @@
+import { format } from "date-fns";
+
+import { getTodayIsoDate } from "~/utils/dato.utils";
+import { addDemoParamsToURL } from "~/utils/demo-params.utils";
+
 export interface IOpprettMeldekortResponse {
   success?: boolean;
   error?: string;
@@ -13,6 +18,11 @@ export interface IOpprettMeldekortPayload {
   fraOgMed: string;
   tilOgMed: string;
   simulering: boolean;
+}
+
+export interface IPeriodeIntervall {
+  fraOgMed: string;
+  tilOgMed: string;
 }
 
 export function buildOpprettMeldekortFormData(payload: IOpprettMeldekortPayload): FormData {
@@ -31,4 +41,32 @@ export function toOpprettMeldekortErrorMessage(response: IOpprettMeldekortRespon
   return response.detail
     ? `${response.error ?? standardFeilmelding}: ${response.detail}`
     : (response.error ?? standardFeilmelding);
+}
+
+export function utledGyldigPeriode(
+  range: { from?: Date; to?: Date } | undefined,
+): IPeriodeIntervall | null {
+  if (!range?.from || !range.to) {
+    return null;
+  }
+
+  const fraOgMed = format(range.from, "yyyy-MM-dd");
+  const tilOgMed = format(range.to, "yyyy-MM-dd");
+  const today = getTodayIsoDate();
+
+  if (fraOgMed > tilOgMed || fraOgMed > today || tilOgMed > today) {
+    return null;
+  }
+
+  return { fraOgMed, tilOgMed };
+}
+
+export function erSammePeriode(a: IPeriodeIntervall | null, b: IPeriodeIntervall | null): boolean {
+  return a !== null && b !== null && a.fraOgMed === b.fraOgMed && a.tilOgMed === b.tilOgMed;
+}
+
+export function byggOpprettMeldekortActionUrl(): string {
+  const actionUrl = new URL("/api/opprett-meldekort", window.location.origin);
+  addDemoParamsToURL(actionUrl);
+  return actionUrl.pathname + actionUrl.search;
 }

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
@@ -12,6 +12,7 @@ export interface IOpprettMeldekortPayload {
   personId: string;
   fraOgMed: string;
   tilOgMed: string;
+  simulering: boolean;
 }
 
 export function buildOpprettMeldekortFormData(payload: IOpprettMeldekortPayload): FormData {
@@ -19,6 +20,7 @@ export function buildOpprettMeldekortFormData(payload: IOpprettMeldekortPayload)
   formData.set("personId", payload.personId);
   formData.set("fraOgMed", payload.fraOgMed);
   formData.set("tilOgMed", payload.tilOgMed);
+  formData.set("simulering", payload.simulering ? "true" : "false");
 
   return formData;
 }

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -104,19 +104,18 @@ export async function hentPeriode<T extends IRapporteringsperiode>(
   );
 }
 
-/** Oppretter ett eller flere meldekort for en person. Med simulering:true opprettes ingenting, kun forhåndsvisning av periodene. */
 export async function opprettMeldekort({
   request,
   personId,
   fraOgMed,
   tilOgMed,
-  simulering = false,
+  simulering,
 }: {
   request: Request;
   personId: string;
   fraOgMed: string;
   tilOgMed: string;
-  simulering?: boolean;
+  simulering: boolean;
 }): Promise<IOpprettMeldekortResponse> {
   const baseUrl = `${getEnv("DP_MELDEKORTREGISTER_URL")}/sb/person/${personId}/meldekort`;
   const url = new URL(baseUrl);

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -104,17 +104,19 @@ export async function hentPeriode<T extends IRapporteringsperiode>(
   );
 }
 
-/** Oppretter ett eller flere meldekort for en person. */
+/** Oppretter ett eller flere meldekort for en person. Med simulering:true opprettes ingenting, kun forhåndsvisning av periodene. */
 export async function opprettMeldekort({
   request,
   personId,
   fraOgMed,
   tilOgMed,
+  simulering = false,
 }: {
   request: Request;
   personId: string;
   fraOgMed: string;
   tilOgMed: string;
+  simulering?: boolean;
 }): Promise<IOpprettMeldekortResponse> {
   const baseUrl = `${getEnv("DP_MELDEKORTREGISTER_URL")}/sb/person/${personId}/meldekort`;
   const url = new URL(baseUrl);
@@ -130,11 +132,11 @@ export async function opprettMeldekort({
       body: JSON.stringify({
         fraOgMed,
         tilOgMed,
-        simulering: false,
+        simulering,
       } satisfies IOpprettMeldekortRequest),
     },
     "Opprettelse av meldekort",
-    { personId, fraOgMed, tilOgMed },
+    { personId, fraOgMed, tilOgMed, simulering },
   );
 }
 

--- a/app/routes/api.opprett-meldekort.ts
+++ b/app/routes/api.opprett-meldekort.ts
@@ -9,6 +9,7 @@ const requestSchema = z.object({
   personId: z.string().min(1),
   fraOgMed: z.iso.date(),
   tilOgMed: z.iso.date(),
+  simulering: z.literal(["true", "false"]).transform((value) => value === "true"),
 });
 
 export async function loader() {
@@ -43,6 +44,7 @@ export async function action({ request }: ActionFunctionArgs) {
       personId: input.personId,
       fraOgMed: input.fraOgMed,
       tilOgMed: input.tilOgMed,
+      simulering: input.simulering,
     });
 
     if (input.fraOgMed > input.tilOgMed) {
@@ -65,11 +67,13 @@ export async function action({ request }: ActionFunctionArgs) {
       personId: input.personId,
       fraOgMed: input.fraOgMed,
       tilOgMed: input.tilOgMed,
+      simulering: input.simulering,
     });
 
     logger.info("[api.opprett-meldekort] Opprett meldekort fullfort", {
       personId: input.personId,
       antallPerioder: result.perioder?.length ?? 0,
+      simulering: input.simulering,
     });
 
     return Response.json({ success: true, ...result });

--- a/app/utils/scenario.types.ts
+++ b/app/utils/scenario.types.ts
@@ -7,6 +7,7 @@ export enum ScenarioType {
   FLERE_BEREGNEDE = "flere_beregnede",
   FULL_DEMO = "FULL_DEMO",
   ARENA_MELDEKORT = "ARENA_MELDEKORT",
+  STOPPET_FOR_3_MANEDER = "stoppet_for_3_maneder",
 }
 
 export interface IScenario {
@@ -42,5 +43,9 @@ export const SCENARIOS: IScenario[] = [
   {
     type: ScenarioType.ARENA_MELDEKORT,
     tittel: "Meldekort migrert fra Arena",
+  },
+  {
+    type: ScenarioType.STOPPET_FOR_3_MANEDER,
+    tittel: "Siste meldekort for 3 måneder siden",
   },
 ];

--- a/vitest/routes/api.opprett-meldekort.test.ts
+++ b/vitest/routes/api.opprett-meldekort.test.ts
@@ -16,7 +16,9 @@ vi.mock("~/models/logger.server", () => ({
 
 function lagRequest(felter: Record<string, string>, method = "POST") {
   const formData = new FormData();
-  Object.entries(felter).forEach(([key, value]) => formData.append(key, value));
+  Object.entries({ simulering: "false", ...felter }).forEach(([key, value]) =>
+    formData.append(key, value),
+  );
 
   return new Request("http://localhost/api/opprett-meldekort", { method, body: formData });
 }
@@ -115,6 +117,33 @@ describe("api.opprett-meldekort", () => {
     );
 
     await expect(response.json()).resolves.toMatchObject({ success: true });
+  });
+
+  it("videreformidler simulering:true til opprettMeldekort uten å opprette noe", async () => {
+    const perioder = [{ fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" }];
+    opprettMeldekort.mockResolvedValue({ perioder });
+
+    const response = await kjorAction(
+      lagRequest({
+        personId: "123",
+        fraOgMed: "2025-01-06",
+        tilOgMed: "2025-01-19",
+        simulering: "true",
+      }),
+    );
+
+    expect(opprettMeldekort).toHaveBeenCalledWith(expect.objectContaining({ simulering: true }));
+    await expect(response.json()).resolves.toEqual({ success: true, perioder });
+  });
+
+  it("sender simulering:false når feltet er false", async () => {
+    opprettMeldekort.mockResolvedValue({ perioder: [] });
+
+    await kjorAction(
+      lagRequest({ personId: "123", fraOgMed: "2025-01-06", tilOgMed: "2025-01-19" }),
+    );
+
+    expect(opprettMeldekort).toHaveBeenCalledWith(expect.objectContaining({ simulering: false }));
   });
 
   it("videreformidler feilrespons fra backend", async () => {


### PR DESCRIPTION
## Beskrivelse
Oppdaterer visning av informasjons boksen til opprett meldekort modalen. Det betyr også at jeg måtte legge til ny mock bruker for å simulere opprettelse av meldekort.
<img width="662" height="687" alt="Screenshot 2026-08-24 at 12 51 56" src="https://github.com/user-attachments/assets/2f5c42ad-b8f1-40fb-8a2f-e58d4643d71d" />

<img width="1268" height="687" alt="Screenshot 2026-08-24 at 12 52 14" src="https://github.com/user-attachments/assets/0688db3d-1e1b-4014-99aa-bab5ca54957b" />

<img width="1268" height="614" alt="Screenshot 2026-08-24 at 12 52 32" src="https://github.com/user-attachments/assets/675ecd95-be45-4a39-be2c-80a6a3ea4d6d" />


## Type endring
- [ ] Bugfix
- [x] Ny funksjonalitet
- [ ] Refaktorering
- [ ] Dokumentasjon
- [ ] Annet

## Sjekkliste
- [x] Koden bygger uten feil (`pnpm run build`)
- [x] Tester er lagt til/oppdatert
- [x] Alle tester passerer (`pnpm test`)
- [ ] README/dokumentasjon er oppdatert (hvis relevant)
