### PR TITLE
vis feilmeldinger knyttet til opprett meldekort 

### DIFF
--- a/app/mocks/mock-meldekortregister.ts
+++ b/app/mocks/mock-meldekortregister.ts
@@ -1,4 +1,4 @@
-import { addDays } from "date-fns";
+import { addDays, format } from "date-fns";
 import { http, HttpResponse } from "msw";
 
 import { logger } from "~/models/logger.server";
@@ -87,6 +87,58 @@ export function mockMeldekortregister(database?: ReturnType<typeof withDb>) {
           periode = lagPeriodeDatoFor(addDays(new Date(periode.tilOgMed), 1));
         }
 
+        const eksisterendePerioder = db
+          .hentAlleRapporteringsperioder()
+          .filter((eksisterende) => eksisterende.ident === person.ident);
+
+        const sisteEksisterendePeriode = eksisterendePerioder.reduce<
+          IRapporteringsperiode | undefined
+        >((siste, eksisterende) => {
+          if (!siste || eksisterende.periode.tilOgMed > siste.periode.tilOgMed) {
+            return eksisterende;
+          }
+          return siste;
+        }, undefined);
+
+        const perioderMedOverlapp = perioder.map((nyPeriode) => {
+          const eksisterendePeriode = eksisterendePerioder.find(
+            (eksisterende) =>
+              nyPeriode.fraOgMed <= eksisterende.periode.tilOgMed &&
+              nyPeriode.tilOgMed >= eksisterende.periode.fraOgMed,
+          );
+
+          return {
+            ...nyPeriode,
+            id: eksisterendePeriode?.id,
+            overlapperEksisterendeMeldekort: Boolean(eksisterendePeriode),
+          };
+        });
+
+        if (perioderMedOverlapp.some((nyPeriode) => nyPeriode.overlapperEksisterendeMeldekort)) {
+          return HttpResponse.json(
+            {
+              perioder: perioderMedOverlapp,
+              title: "Overlappende meldekort",
+              detail: "Ett eller flere meldekort overlapper eksisterende meldekort.",
+            },
+            { status: 422 },
+          );
+        }
+
+        if (
+          sisteEksisterendePeriode &&
+          body.fraOgMed !==
+            format(addDays(new Date(sisteEksisterendePeriode.periode.tilOgMed), 1), "yyyy-MM-dd")
+        ) {
+          return HttpResponse.json(
+            {
+              title: "Ugyldig startdato",
+              detail: "Fra-dato må være dagen etter siste eksisterende meldekort.",
+            },
+            { status: 422 },
+          );
+        }
+
         const opprettedePerioder: IRapporteringsperiode[] = [];
         if (!body.simulering) {
           for (const nyPeriode of perioder) {
@@ -105,7 +157,7 @@ export function mockMeldekortregister(database?: ReturnType<typeof withDb>) {
 
         return HttpResponse.json({
           perioder: body.simulering
-            ? perioder
+            ? perioderMedOverlapp
             : opprettedePerioder.map(({ id, periode }) => ({
                 id,
                 ...periode,

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -148,17 +148,18 @@ describe("OpprettMeldekortModal", () => {
     expect(onCloseMock).not.toHaveBeenCalled();
   });
 
-  it("skal vise valideringsfeil når personId mangler", async () => {
+  it("skal ikke opprette meldekort når personId mangler", async () => {
     const user = userEvent.setup();
     const onCloseMock = vi.fn();
+    const actionMock = vi.fn(() => ({ success: true }));
 
-    renderWithProviders(<OpprettMeldekortModal open={true} onClose={onCloseMock} />);
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={onCloseMock} />, actionMock);
 
     await user.type(screen.getByLabelText("Fra dato"), "01.01.2024");
     await user.type(screen.getByLabelText("Til dato"), "14.01.2024");
     await user.click(screen.getByRole("button", { name: "Opprett" }));
 
-    expect(await screen.findByText("Mangler personId.")).toBeInTheDocument();
+    expect(actionMock).not.toHaveBeenCalled();
     expect(onCloseMock).not.toHaveBeenCalled();
   });
 

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.test.tsx
@@ -48,7 +48,11 @@ mockUseRouteLoaderData.mockReturnValue({
 
 function renderWithProviders(
   ui: React.ReactElement,
-  actionResponse: IOpprettMeldekortResponse = { success: true },
+  actionResponse:
+    | IOpprettMeldekortResponse
+    | ((request: Request) => IOpprettMeldekortResponse | Promise<IOpprettMeldekortResponse>) = {
+    success: true,
+  },
 ) {
   const Stub = createRoutesStub([
     {
@@ -57,7 +61,8 @@ function renderWithProviders(
     },
     {
       path: "/api/opprett-meldekort",
-      action: () => actionResponse,
+      action: ({ request }) =>
+        typeof actionResponse === "function" ? actionResponse(request) : actionResponse,
     },
   ]);
 
@@ -190,22 +195,41 @@ describe("OpprettMeldekortModal", () => {
 
     renderWithProviders(
       <OpprettMeldekortModal open={true} onClose={onCloseMock} personId="123" />,
-      {
-        error: "Kunne ikke opprette meldekort",
-        detail: "Ugyldig periode",
-      },
+      async (request) =>
+        (await request.formData()).get("simulering") === "true"
+          ? { success: true, perioder: [] }
+          : { error: "Kunne ikke opprette meldekort", detail: "Ugyldig periode" },
     );
 
     await user.type(screen.getByLabelText("Fra dato"), "01.01.2024");
     await user.type(screen.getByLabelText("Til dato"), "14.01.2024");
     await user.click(screen.getByRole("button", { name: "Opprett" }));
 
+    expect(await screen.findByText("Kunne ikke opprette meldekort")).toBeInTheDocument();
     expect(
-      await screen.findByText("Kunne ikke opprette meldekort: Ugyldig periode", undefined, {
-        timeout: 5000,
-      }),
+      screen.getByText(
+        "Meldekort kunne ikke opprettes. Prøv igjen, og hvis du fortsatt har problemer kontakt brukerstøtte.",
+      ),
     ).toBeInTheDocument();
     expect(onCloseMock).not.toHaveBeenCalled();
+  });
+
+  it("skal vise generell feilmelding når forhåndsvisningen feiler", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<OpprettMeldekortModal open={true} onClose={vi.fn()} personId="123" />, {
+      error: "Forhåndsvisning feilet",
+    });
+
+    await user.type(screen.getByLabelText("Fra dato"), "01.01.2024");
+    await user.type(screen.getByLabelText("Til dato"), "14.01.2024");
+
+    expect(await screen.findByText("Kan ikke forhåndsvise meldekort")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Forhåndsvisningen funker ikke som den skal. En mulig årsak er at datoene du har valgt ikke stemmer overens med brukers meldesyklus. Prøv å justere datoene, eller ta kontakt med brukerstøtte.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("skal vise brukernavn i tittel når det er oppgitt", () => {

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -1,15 +1,16 @@
 import { ExclamationmarkTriangleIcon } from "@navikt/aksel-icons";
 import {
-  Alert,
   BodyShort,
   Button,
   DatePicker,
   InfoCard,
+  LocalAlert,
   Modal,
   Skeleton,
   useRangeDatepicker,
 } from "@navikt/ds-react";
 import { format } from "date-fns";
+import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useFetcher, useNavigate, useRouteLoaderData } from "react-router";
 
@@ -25,10 +26,27 @@ import {
   type IOpprettMeldekortPayload,
   type IOpprettMeldekortResponse,
   type IPeriodeIntervall,
-  toOpprettMeldekortErrorMessage,
   utledGyldigPeriode,
 } from "./opprettMeldekortModal.helpers";
 import styles from "./opprettMeldekortModal.module.css";
+
+interface OpprettMeldekortAlertProps {
+  tittel?: string;
+  innhold: ReactNode;
+}
+
+function OpprettMeldekortAlert({ tittel, innhold }: OpprettMeldekortAlertProps) {
+  return (
+    <LocalAlert status="error">
+      {tittel && (
+        <LocalAlert.Header>
+          <LocalAlert.Title>{tittel}</LocalAlert.Title>
+        </LocalAlert.Header>
+      )}
+      <LocalAlert.Content>{innhold}</LocalAlert.Content>
+    </LocalAlert>
+  );
+}
 
 interface OpprettMeldekortModalProps {
   open: boolean;
@@ -56,6 +74,7 @@ export function OpprettMeldekortModal({
 
   const tekster = rootData?.sanityData?.opprettMeldekortModal;
   const [actionError, setActionError] = useState<string | undefined>();
+  const [opprettelseFeilet, setOpprettelseFeilet] = useState(false);
   const [visDatoFeil, setVisDatoFeil] = useState(false);
   const [hasPendingSubmission, setHasPendingSubmission] = useState(false);
   const fetcher = useFetcher<IOpprettMeldekortResponse>();
@@ -73,6 +92,7 @@ export function OpprettMeldekortModal({
 
   function resetFormState() {
     setActionError(undefined);
+    setOpprettelseFeilet(false);
     setVisDatoFeil(false);
     setHasPendingSubmission(false);
     reset();
@@ -88,6 +108,7 @@ export function OpprettMeldekortModal({
     setHasPendingSubmission(false);
 
     if (fetcher.data.success) {
+      setOpprettelseFeilet(false);
       onBekreft?.(fetcher.data.perioder ?? []);
       if (fetcher.data.redirectUrl) {
         navigate(fetcher.data.redirectUrl);
@@ -97,7 +118,7 @@ export function OpprettMeldekortModal({
       return;
     }
 
-    setActionError(toOpprettMeldekortErrorMessage(fetcher.data));
+    setOpprettelseFeilet(true);
   }, [hasPendingSubmission, fetcher.state, fetcher.data, onBekreft, onClose]);
 
   function startSimuleringAvMeldekortOpprettelse() {
@@ -106,6 +127,8 @@ export function OpprettMeldekortModal({
       return;
     }
 
+    setActionError(undefined);
+    setOpprettelseFeilet(false);
     ventendeRangeRef.current = valgtPeriode;
 
     simuleringFetcher.submit(
@@ -129,6 +152,8 @@ export function OpprettMeldekortModal({
   }, [simuleringFetcher.state, simuleringFetcher.data]);
 
   function handleBekreft() {
+    setOpprettelseFeilet(false);
+
     if (!selectedRange?.from || !selectedRange.to) {
       setVisDatoFeil(true);
       setActionError(undefined);
@@ -177,9 +202,18 @@ export function OpprettMeldekortModal({
     Boolean(personId) && valgtPeriode !== null && simuleringFetcher.state !== "idle";
 
   const simulertePerioder =
-    erSammePeriode(simulertRange, valgtPeriode) && simuleringFetcher.data?.success
+    erSammePeriode(simulertRange, valgtPeriode) && simuleringFetcher.data
       ? (simuleringFetcher.data.perioder ?? [])
       : [];
+
+  const simuleringHarOverlapp =
+    erSammePeriode(simulertRange, valgtPeriode) &&
+    Boolean(simuleringFetcher.data && !simuleringFetcher.data.success) &&
+    simulertePerioder.some((periode) => periode.overlapperEksisterendeMeldekort);
+
+  const simuleringHarFeil =
+    erSammePeriode(simulertRange, valgtPeriode) &&
+    Boolean(simuleringFetcher.data && !simuleringFetcher.data.success);
 
   const infoBoksTekst = sanityTekst(
     tekster?.infoBoks?.tekst,
@@ -227,7 +261,6 @@ export function OpprettMeldekortModal({
               />
             </div>
           </DatePicker>
-          {actionError && <Alert variant="error">{actionError}</Alert>}
           <BodyShort>{forklaringstekst}</BodyShort>
           {lasterSimulering && (
             <Skeleton
@@ -244,7 +277,21 @@ export function OpprettMeldekortModal({
                 "opprettMeldekortModal.infoBoks.tittel",
               )}
               tekst={infoBoksTekst}
+              attention={simuleringHarOverlapp}
               perioder={simulertePerioder}
+            />
+          )}
+          {actionError && <OpprettMeldekortAlert innhold={actionError} />}
+          {opprettelseFeilet && (
+            <OpprettMeldekortAlert
+              tittel="Kunne ikke opprette meldekort"
+              innhold="Meldekort kunne ikke opprettes. Prøv igjen, og hvis du fortsatt har problemer kontakt brukerstøtte."
+            />
+          )}
+          {simuleringHarFeil && !simuleringHarOverlapp && (
+            <OpprettMeldekortAlert
+              tittel="Kan ikke forhåndsvise meldekort"
+              innhold="Forhåndsvisningen funker ikke som den skal. En mulig årsak er at datoene du har valgt ikke stemmer overens med brukers meldesyklus. Prøv å justere datoene, eller ta kontakt med brukerstøtte."
             />
           )}
         </div>
@@ -255,6 +302,11 @@ export function OpprettMeldekortModal({
           onClick={handleBekreft}
           size="small"
           loading={hasPendingSubmission && fetcher.state !== "idle"}
+          disabled={
+            simuleringHarFeil ||
+            simuleringHarOverlapp ||
+            (hasPendingSubmission && fetcher.state !== "idle")
+          }
         >
           {sanityTekst(tekster?.submitKnapp, "opprettMeldekortModal.submitKnapp")}
         </Button>

--- a/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
+++ b/app/modals/opprett-meldekort/OpprettMeldekortModal.tsx
@@ -73,7 +73,6 @@ export function OpprettMeldekortModal({
   }
 
   const tekster = rootData?.sanityData?.opprettMeldekortModal;
-  const [actionError, setActionError] = useState<string | undefined>();
   const [opprettelseFeilet, setOpprettelseFeilet] = useState(false);
   const [visDatoFeil, setVisDatoFeil] = useState(false);
   const [hasPendingSubmission, setHasPendingSubmission] = useState(false);
@@ -91,7 +90,6 @@ export function OpprettMeldekortModal({
     });
 
   function resetFormState() {
-    setActionError(undefined);
     setOpprettelseFeilet(false);
     setVisDatoFeil(false);
     setHasPendingSubmission(false);
@@ -127,7 +125,6 @@ export function OpprettMeldekortModal({
       return;
     }
 
-    setActionError(undefined);
     setOpprettelseFeilet(false);
     ventendeRangeRef.current = valgtPeriode;
 
@@ -156,24 +153,20 @@ export function OpprettMeldekortModal({
 
     if (!selectedRange?.from || !selectedRange.to) {
       setVisDatoFeil(true);
-      setActionError(undefined);
       return;
     }
 
     setVisDatoFeil(false);
 
     if (!personId) {
-      setActionError("Mangler personId.");
       return;
     }
 
-    setActionError(undefined);
     const fraOgMed = format(selectedRange.from, "yyyy-MM-dd");
     const tilOgMed = format(selectedRange.to, "yyyy-MM-dd");
     const today = getTodayIsoDate();
 
     if (fraOgMed > today || tilOgMed > today) {
-      setActionError("Fra-dato og til-dato kan ikke være frem i tid.");
       return;
     }
 
@@ -281,7 +274,6 @@ export function OpprettMeldekortModal({
               perioder={simulertePerioder}
             />
           )}
-          {actionError && <OpprettMeldekortAlert innhold={actionError} />}
           {opprettelseFeilet && (
             <OpprettMeldekortAlert
               tittel="Kunne ikke opprette meldekort"

--- a/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
+++ b/app/modals/opprett-meldekort/components/OpprettMeldekortInfoBoks.tsx
@@ -1,3 +1,4 @@
+import { ExclamationmarkTriangleIcon } from "@navikt/aksel-icons";
 import { BodyShort, InfoCard } from "@navikt/ds-react";
 
 import { DatoFormat, formaterPeriodeTilUkenummer, formatterDato } from "~/utils/dato.utils";
@@ -7,12 +8,18 @@ import styles from "./opprettMeldekortInfoBoks.module.css";
 interface OpprettMeldekortInfoBoksProps {
   tittel: string;
   tekst: string;
-  perioder: Array<{ fraOgMed: string; tilOgMed: string }>;
+  attention?: boolean;
+  perioder: Array<{
+    fraOgMed: string;
+    tilOgMed: string;
+    overlapperEksisterendeMeldekort?: boolean;
+  }>;
 }
 
 export function OpprettMeldekortInfoBoks({
   tittel,
   tekst,
+  attention = false,
   perioder,
 }: OpprettMeldekortInfoBoksProps) {
   const [tekstFor, tekstEtter] = tekst.includes("{{antall}}")
@@ -20,7 +27,7 @@ export function OpprettMeldekortInfoBoks({
     : [tekst, ""];
 
   return (
-    <InfoCard data-color="info" size="small">
+    <InfoCard data-color={attention ? "warning" : "info"} size="small">
       <InfoCard.Header>
         <InfoCard.Title>{tittel}</InfoCard.Title>
       </InfoCard.Header>
@@ -35,20 +42,41 @@ export function OpprettMeldekortInfoBoks({
             <colgroup>
               <col className={styles.ukenummerKolonne} />
               <col className={styles.periodeKolonne} />
+              <col className={styles.varselskolonne} />
             </colgroup>
             <thead>
               <tr>
                 <th scope="col">Ukenummer</th>
                 <th scope="col">Periode</th>
+                <th scope="col" aria-label="Varsel" />
               </tr>
             </thead>
             <tbody>
               {perioder.map((periode) => (
-                <tr key={`${periode.fraOgMed}-${periode.tilOgMed}`}>
+                <tr
+                  key={`${periode.fraOgMed}-${periode.tilOgMed}`}
+                  className={
+                    periode.overlapperEksisterendeMeldekort ? styles.overlappendePeriode : undefined
+                  }
+                >
                   <td>{formaterPeriodeTilUkenummer(periode.fraOgMed, periode.tilOgMed)}</td>
                   <td>
                     {formatterDato({ dato: periode.fraOgMed, format: DatoFormat.DagMndAar })} –{" "}
                     {formatterDato({ dato: periode.tilOgMed, format: DatoFormat.DagMndAar })}
+                  </td>
+                  <td
+                    className={styles.varselcelle}
+                    aria-label={
+                      periode.overlapperEksisterendeMeldekort
+                        ? "Overlapper eksisterende meldekort"
+                        : undefined
+                    }
+                  >
+                    <span className={styles.varselikon}>
+                      {periode.overlapperEksisterendeMeldekort && (
+                        <ExclamationmarkTriangleIcon aria-hidden />
+                      )}
+                    </span>
                   </td>
                 </tr>
               ))}

--- a/app/modals/opprett-meldekort/components/opprettMeldekortInfoBoks.module.css
+++ b/app/modals/opprett-meldekort/components/opprettMeldekortInfoBoks.module.css
@@ -4,10 +4,13 @@
 }
 
 .periodeTabellWrapper {
+  max-width: 100%;
+  overflow-x: auto;
   padding: var(--ax-space-6) var(--ax-space-12);
 }
 
 .periodeTabell {
+  min-width: 28rem;
   width: 100%;
   border-collapse: collapse;
 }
@@ -31,5 +34,26 @@
 }
 
 .periodeKolonne {
-  width: 67%;
+  width: 62%;
+}
+
+.varselskolonne {
+  width: 5%;
+}
+
+.overlappendePeriode {
+  color: var(--ax-text-warning-subtle);
+}
+
+.varselcelle {
+  text-align: right !important;
+  vertical-align: middle;
+  color: var(--ax-text-warning-subtle);
+}
+
+.varselikon {
+  display: flex;
+  min-height: 100%;
+  align-items: center;
+  justify-content: flex-end;
 }

--- a/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
+++ b/app/modals/opprett-meldekort/opprettMeldekortModal.helpers.ts
@@ -12,6 +12,7 @@ export interface IOpprettMeldekortResponse {
     id?: string;
     fraOgMed: string;
     tilOgMed: string;
+    overlapperEksisterendeMeldekort?: boolean;
   }>;
 }
 

--- a/app/models/rapporteringsperiode.server.ts
+++ b/app/models/rapporteringsperiode.server.ts
@@ -25,6 +25,7 @@ export interface IOpprettMeldekortResponse {
     id?: string;
     fraOgMed: string;
     tilOgMed: string;
+    overlapperEksisterendeMeldekort?: boolean;
   }>;
 }
 
@@ -134,6 +135,7 @@ export async function opprettMeldekort({
         tilOgMed,
         simulering,
       } satisfies IOpprettMeldekortRequest),
+      includeErrorData: true,
     },
     "Opprettelse av meldekort",
     { personId, fraOgMed, tilOgMed, simulering },

--- a/app/routes/person.$personId.perioder.tsx
+++ b/app/routes/person.$personId.perioder.tsx
@@ -1,5 +1,4 @@
-import { ExclamationmarkTriangleIcon } from "@navikt/aksel-icons";
-import { Accordion, Heading, InfoCard } from "@navikt/ds-react";
+import { Accordion, Heading, LocalAlert } from "@navikt/ds-react";
 import { useEffect, useRef, useState } from "react";
 import { useRouteLoaderData, useSearchParams } from "react-router";
 
@@ -141,16 +140,16 @@ export default function Rapportering({ params, loaderData }: Route.ComponentProp
         )}
         {perioder.length === 0 ? (
           <section aria-labelledby="ingen-meldekort-tittel">
-            <InfoCard data-color="warning" size="small">
-              <InfoCard.Header icon={<ExclamationmarkTriangleIcon aria-hidden />}>
-                <InfoCard.Title id="ingen-meldekort-tittel">
+            <LocalAlert status="error">
+              <LocalAlert.Header>
+                <LocalAlert.Title id="ingen-meldekort-tittel">
                   Her har det skjedd en feil
-                </InfoCard.Title>
-              </InfoCard.Header>
-              <InfoCard.Content>
+                </LocalAlert.Title>
+              </LocalAlert.Header>
+              <LocalAlert.Content>
                 Her mangler det meldekort. Ta kontakt med brukerstøtte.
-              </InfoCard.Content>
-            </InfoCard>
+              </LocalAlert.Content>
+            </LocalAlert>
           </section>
         ) : (
           <section aria-label="Meldekort gruppert etter år">

--- a/app/styles/route-styles/perioder.module.css
+++ b/app/styles/route-styles/perioder.module.css
@@ -1,5 +1,6 @@
 .perioder-page-container {
   max-width: 1400px;
+  width: 100%;
   margin: 0 auto;
   display: flex;
   flex: 1;
@@ -13,6 +14,7 @@
   background-color: var(--ax-bg-default);
   display: flex;
   box-sizing: border-box;
+  width: 100%;
   padding: 0 1rem;
   flex-direction: column;
   justify-content: flex-start;

--- a/app/styles/route-styles/root.module.css
+++ b/app/styles/route-styles/root.module.css
@@ -35,6 +35,7 @@
   width: 100%;
   max-width: 1400px;
   margin: 0 auto;
+  flex-direction: column;
 }
 
 .variantSwitcherContainer {

--- a/app/utils/http-client.server.ts
+++ b/app/utils/http-client.server.ts
@@ -17,12 +17,16 @@ interface SafeFetchOptions {
   headers: HeadersInit;
   body?: string;
   parseJson?: boolean;
+  includeErrorData?: boolean;
 }
 
 /**
  * Parser HttpProblem fra backend response
  */
-async function parseHttpProblem(response: Response): Promise<IHttpProblem | null> {
+async function parseHttpProblem(
+  response: Response,
+  includeErrorData: boolean,
+): Promise<IHttpProblem | null> {
   try {
     const contentType = response.headers.get("content-type");
     const isJson =
@@ -32,7 +36,14 @@ async function parseHttpProblem(response: Response): Promise<IHttpProblem | null
     if (!isJson) return null;
 
     const data = await response.json();
-    return data.title && data.status && data.correlationId ? (data as IHttpProblem) : null;
+    if (!data.title && !(includeErrorData && data.perioder)) return null;
+
+    return {
+      ...data,
+      title: data.title ?? "Kunne ikke opprette meldekort.",
+      status: data.status ?? response.status,
+      correlationId: data.correlationId ?? uuidv7(),
+    } as IHttpProblem;
   } catch {
     return null;
   }
@@ -61,6 +72,7 @@ function throwHttpProblem(
       details: httpProblem.detail,
       correlationId: httpProblem.correlationId,
       errorType: httpProblem.errorType,
+      perioder: httpProblem.perioder,
     },
     { status: httpProblem.status },
   );
@@ -112,8 +124,9 @@ async function handleErrorResponse(
   response: Response,
   context: string,
   metadata?: Record<string, unknown>,
+  includeErrorData = false,
 ): Promise<never> {
-  const httpProblem = await parseHttpProblem(response);
+  const httpProblem = await parseHttpProblem(response, includeErrorData);
   return httpProblem
     ? throwHttpProblem(httpProblem, context, metadata)
     : throwFallbackError(response, context, metadata);
@@ -135,7 +148,7 @@ export async function httpRequest<T>(
   const response = await fetch(url, options);
 
   if (!response.ok) {
-    await handleErrorResponse(response, context, metadata);
+    await handleErrorResponse(response, context, metadata, options.includeErrorData ?? false);
   }
 
   // Response er OK (200-299), parse JSON

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -49,6 +49,7 @@ export interface IHttpProblem {
   instance: string;
   errorType?: string;
   correlationId: string;
+  perioder?: unknown;
 }
 
 export type TAktivitetType = (typeof AKTIVITET_TYPE)[keyof typeof AKTIVITET_TYPE];


### PR DESCRIPTION
## Beskrivelse
Her viser vi ulike feilmeldinger knyttet til opprett meldekort, inkl at bruker ikke har meldekort. 

MERK: all tekst skal hentes fra Sanity (gjøres i egen PR) OG det er en rekke tekster som fremdeles jobbes med.

Merk også at det hele gjør mockendepunktet litt mer komplisert enn nødvendig.

Se bilder under for hva som blir gjort. 

Kallet for å hente meldekort returnerer []. Her er ikke tekster ferdigstilt:
<img width="2032" height="1072" alt="Screenshot 2026-08-27 at 14 25 33" src="https://github.com/user-attachments/assets/925a2976-454b-42fb-8143-70034f494f0d" />
<img width="2032" height="1072" alt="Screenshot 2026-08-27 at 14 25 55" src="https://github.com/user-attachments/assets/d4f47ded-0a6c-4aa7-a390-6ee63f6a9647" />

Generell feil ved forhåndsvisning av meldekort:
<img width="2032" height="1072" alt="Screenshot 2026-08-27 at 14 27 28" src="https://github.com/user-attachments/assets/15bb1bd3-d932-49e6-915e-2205ca2b7ea3" />

Overlappende eksisterende meldekort. Tekstinnhold er ikke ferdigstilt:
<img width="2032" height="1072" alt="Screenshot 2026-08-27 at 14 27 50" src="https://github.com/user-attachments/assets/b46508d7-c1c4-4ba4-828d-896c30cbea70" />

Feil ved opprettelse av meldekort:
<img width="1988" height="1028" alt="Screenshot 2026-08-27 at 14 29 02" src="https://github.com/user-attachments/assets/49683962-a9d1-4dcf-8ef3-b997bb023045" />


## Type endring
- [ ] Bugfix
- [ ] Ny funksjonalitet
- [ ] Refaktorering
- [ ] Dokumentasjon
- [ ] Annet

## Sjekkliste
- [ ] Koden bygger uten feil (`pnpm run build`)
- [ ] Tester er lagt til/oppdatert
- [ ] Alle tester passerer (`pnpm test`)
- [ ] README/dokumentasjon er oppdatert (hvis relevant)
